### PR TITLE
fix lint warning in ApiService

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -27,7 +27,7 @@ export interface ExtendedAxiosRequestConfig extends AxiosRequestConfig {
  * Интерфейс для ответа от сервера при обновлении токена
  */
 interface RefreshTokenResponseData {
-  accessToken: string;
+  token: string;
   refreshToken: string;
 }
 
@@ -149,7 +149,7 @@ export class ApiService {
               return Promise.reject(new Error('No refresh token available'));
             }
 
-            const response = await this.instance.post<{ data: { token: string; refreshToken: string } }>(
+            const response = await this.instance.post<{ data: RefreshTokenResponseData }>(
               '/auth/refresh',
               {
                 refreshToken,


### PR DESCRIPTION
## Summary
- replace unused RefreshTokenResponseData interface with typed usage in ApiService
- include typed response for refresh token call to satisfy lint

## Testing
- `./gradlew test`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_688f5968af30832284f21503464a9a49