### PR TITLE
ci: wait for infra services in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -141,8 +141,7 @@ jobs:
       - name: Start infrastructure services
         run: |
           cd infra/docker/compose
-          docker compose up -d postgres kafka zookeeper
-          sleep 30
+          docker compose up -d --wait --wait-timeout 120 postgres kafka zookeeper
 
       - name: Run integration tests
         run: ./gradlew integrationTest || true


### PR DESCRIPTION
## Summary
- ensure integration tests wait for Postgres, Kafka, and Zookeeper to become healthy

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 140}}}' .github/workflows/security.yml`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68925661a9ac832287cbf64a1fc0b8a9