### PR TITLE
Use Gradle build command in backend CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build JARs (skip tests)
-        run: ./gradlew build -x test
+      - name: Build JARs
+        run: ./gradlew build
 
       - name: Upload backend build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -6,7 +6,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-'on':
+on:
   workflow_dispatch:
   push:
     branches: [main, develop]


### PR DESCRIPTION
## Summary
- build backend artifacts with `./gradlew build`
- rely on `./gradlew clean test` for tests while caching speeds up subsequent builds

## Testing
- `./gradlew clean test`
- `./gradlew build`
- `./gradlew build` (again, cached)


------
https://chatgpt.com/codex/tasks/task_e_6892565e38148322b8cb1778d462cd67