### PR TITLE
Ensure workflow linters fail on errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,11 +32,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install validation tools
+        shell: bash
         run: |
+          set -o pipefail
           # Install yq for YAML validation
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
-          
+
           # Install shellcheck for shell scripts
           sudo apt-get update
           sudo apt-get install -y shellcheck
@@ -83,20 +85,21 @@ jobs:
         run: docker compose -f infra/docker/compose/docker-compose.yml config > /dev/null
 
       - name: Check for latest tags
+        shell: bash
         run: |
+          set -o pipefail
           if grep -q ":latest" infra/docker/compose/docker-compose.yml; then
             echo "Found :latest tags in docker-compose.yml!"
             exit 1
           fi
 
       - name: Validate shell scripts
-        run: |
-          find . -name "*.sh" -not -path "./node_modules/*" | while read -r script; do
-            shellcheck -x "$script" || echo "Warning in $script"
-          done
+        run: find . -name "*.sh" -not -path "*/node_modules/*" -exec shellcheck -x {} +
 
       - name: Run infrastructure validation
+        shell: bash
         run: |
+          set -o pipefail
           chmod +x infra/scripts/validate-infrastructure.sh
           ./infra/scripts/validate-infrastructure.sh --quick
 

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -36,39 +36,32 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Install linting tools
+        shell: bash
         run: |
+          set -o pipefail
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
-          
+
           sudo apt-get update
           sudo apt-get install -y shellcheck
-          
+
           sudo wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
           sudo chmod +x /usr/local/bin/hadolint
 
       - name: Lint YAML files
         run: |
-          find infra -name "*.yml" -o -name "*.yaml" | while read -r yaml_file; do
-            echo "Checking: $yaml_file"
-            yq eval '.' "$yaml_file" > /dev/null
-          done
+          find infra \( -name "*.yml" -o -name "*.yaml" \) -exec yq eval '.' {} + > /dev/null
 
       - name: Lint shell scripts
-        run: |
-          find . -name "*.sh" -not -path "./node_modules/*" | while read -r script; do
-            echo "Checking: $script"
-            shellcheck -x "$script"
-          done
+        run: find . -name "*.sh" -not -path "*/node_modules/*" -exec shellcheck -x {} +
 
       - name: Lint Dockerfiles
-        run: |
-          find infra/docker/images -name "Dockerfile.*" | while read -r dockerfile; do
-            echo "Checking: $dockerfile"
-            hadolint "$dockerfile"
-          done
+        run: find infra/docker/images -name "Dockerfile.*" -exec hadolint {} +
 
       - name: Prepare environment for validation
+        shell: bash
         run: |
+          set -o pipefail
           # Создаем .env файл из .env.example с тестовыми паролями для валидации
           sed 's/POSTGRES_PASSWORD=$/POSTGRES_PASSWORD=test_password_123/' infra/docker/compose/.env.example | \
           sed 's/GRAFANA_ADMIN_PASSWORD=$/GRAFANA_ADMIN_PASSWORD=test_password_123/' | \
@@ -76,7 +69,9 @@ jobs:
           sed 's/KIBANA_PASSWORD=$/KIBANA_PASSWORD=test_password_123/' > infra/docker/compose/.env
 
       - name: Quick infrastructure validation
+        shell: bash
         run: |
+          set -o pipefail
           if [ -f "infra/scripts/validate-infrastructure.sh" ]; then
             chmod +x infra/scripts/validate-infrastructure.sh
             ./infra/scripts/validate-infrastructure.sh --quick


### PR DESCRIPTION
## Summary
- enforce `bash -o pipefail` on multi-command steps
- replace `find | while read` loops with `find -exec` for shellcheck, yq, and hadolint

## Testing
- `act -j infrastructure-lint -W .github/workflows/workflow-lint.yml -P ubuntu-latest=catthehacker/ubuntu:act-latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `find . -name "*.sh" -not -path "*/node_modules/*" -exec shellcheck -x {} +` *(shows linter errors for test script)*


------
https://chatgpt.com/codex/tasks/task_e_6892566548608322a685b169e052fa93