### PR TITLE
chore: add reusable ci tools action

### DIFF
--- a/.github/actions/ci-tools/Dockerfile
+++ b/.github/actions/ci-tools/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:22.04
+
+ARG YQ_VERSION=4.47.1
+ARG SHELLCHECK_VERSION=0.11.0
+ARG HADOLINT_VERSION=2.12.0
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq \
+    && chmod +x /usr/local/bin/yq
+
+RUN curl -sSL https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz \
+    | tar -xJ && \
+    mv shellcheck-v${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck && \
+    chmod +x /usr/local/bin/shellcheck && \
+    rm -rf shellcheck-v${SHELLCHECK_VERSION}
+
+RUN curl -sSL https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64 -o /usr/local/bin/hadolint \
+    && chmod +x /usr/local/bin/hadolint
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/ci-tools/action.yml
+++ b/.github/actions/ci-tools/action.yml
@@ -1,0 +1,5 @@
+name: 'CI Tools'
+description: 'Provide yq, shellcheck, and hadolint'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/ci-tools/entrypoint.sh
+++ b/.github/actions/ci-tools/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+mkdir -p /github/workspace/.ci-tools
+cp /usr/local/bin/yq /github/workspace/.ci-tools/
+cp /usr/local/bin/shellcheck /github/workspace/.ci-tools/
+cp /usr/local/bin/hadolint /github/workspace/.ci-tools/
+chmod +x /github/workspace/.ci-tools/*
+echo "/github/workspace/.ci-tools" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,15 +33,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install validation tools
-        run: |
-          # Install yq for YAML validation
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
-          
-          # Install shellcheck for shell scripts
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+      - name: Setup validation tools
+        uses: ./.github/actions/ci-tools
 
       - name: Create test .env file
         run: envsubst < infra/docker/compose/.env.ci > infra/docker/compose/.env

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -39,17 +39,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
-      - name: Install linting tools
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
-          
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
-          
-          sudo wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
-          sudo chmod +x /usr/local/bin/hadolint
+
+      - name: Setup linting tools
+        uses: ./.github/actions/ci-tools
 
       - name: Lint YAML files
         run: |


### PR DESCRIPTION
## Summary
- add docker-based CI tools action with yq 4.47.1, shellcheck 0.11.0 and hadolint 2.12.0
- reuse the action in deploy and workflow-lint workflows

## Testing
- `/tmp/hadolint .github/actions/ci-tools/Dockerfile`
- `/tmp/actionlint -color`
- `/tmp/shellcheck .github/actions/ci-tools/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68926f75be0483229d235d05209a8892