### PR TITLE
ci: build backend once and reuse jars

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,10 +20,37 @@ on:
       - '.github/workflows/security.yml'
 
 jobs:
+  build-backend:
+    name: Build backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Build backend modules
+        run: |
+          chmod +x gradlew
+          ./gradlew build -x test
+
+      - name: Upload backend JARs
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-jars
+          path: backend-*/build/libs/*.jar
+
   docker-security-scan:
     name: Docker Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: build-backend
     strategy:
       fail-fast: false
       matrix:
@@ -61,11 +88,12 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
 
-      - name: Build Java applications
+      - name: Download backend JARs
         if: matrix.service != 'frontend'
-        run: |
-          chmod +x gradlew
-          ./gradlew build -x test
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-jars
+          path: .
 
       - name: Build frontend application
         if: matrix.service == 'frontend'


### PR DESCRIPTION
## Summary
- build backend modules in a dedicated job
- reuse prebuilt backend jars in docker security scan

## Testing
- `./gradlew build -x test` *(fails: package com.google.protobuf.RuntimeVersion does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68928c33415c8322b3f9a0ace2262b77