### PR TITLE
Make gradlew executable and remove redundant workflow steps

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -41,9 +41,6 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
       - name: Build JARs
         run: ./gradlew build
 

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -28,9 +28,6 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
       - name: Run dependency vulnerability scan
         run: ./gradlew dependencyCheckAnalyze
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Build backend modules
         run: |
-          chmod +x gradlew
           ./gradlew build -x test
 
       - name: Upload backend JARs
@@ -165,7 +164,6 @@ jobs:
 
       - name: Build application
         run: |
-          chmod +x gradlew
           ./gradlew build -x test
 
       - name: Prepare test environment


### PR DESCRIPTION
## Summary
- ensure gradlew is tracked as executable
- drop `chmod` steps from workflows now that gradlew is executable

## Testing
- `./gradlew test` *(fails: There were failing tests.)*
- `./gradlew --version`


------
https://chatgpt.com/codex/tasks/task_e_6892914d9014832284ae67c768306b5b