### PR TITLE
chore: cache Trivy DB per OS

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -61,14 +61,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set Trivy DB version
-        run: echo "TRIVY_DB_VERSION=$(date -u +'%Y-%m-%d')" >> "$GITHUB_ENV"
-
       - name: Cache Trivy vulnerability database
         uses: actions/cache@v4
         with:
           path: ~/.cache/trivy
-          key: trivy-db-${{ env.TRIVY_DB_VERSION }}
+          key: trivy-db-${{ runner.os }}
           restore-keys: trivy-db-
 
       - name: Set up JDK 21


### PR DESCRIPTION
## Summary
- use runner OS for Trivy DB cache key

## Testing
- `./gradlew test` *(fails: Execution failed for task ':backend-crew:backend-crew-service:test')*


------
https://chatgpt.com/codex/tasks/task_e_6892f69af9fc832294c15d8aac3fbbe8