### PR TITLE
ci: use buildx action for deploy build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,13 @@ jobs:
         run: envsubst < infra/docker/compose/.env.ci > infra/docker/compose/.env
 
       - name: Build Docker images
-        run: docker compose -f infra/docker/compose/docker-compose.yml build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/compose/docker-compose.yml
+          load: true
+          cache-from: type=gha,scope=deploy
+          cache-to: type=gha,mode=max,scope=deploy
 
       - name: Deploy to ${{ github.event.inputs.environment }}
         run: echo "Deploying to ${{ github.event.inputs.environment }} environment"


### PR DESCRIPTION
## Summary
- switch deploy workflow to docker/build-push-action@v5
- enable GitHub Actions cache for deploy build

## Testing
- `./gradlew test` *(fails: Execution failed for task ':backend-crew:backend-crew-service:test')*


------
https://chatgpt.com/codex/tasks/task_e_68930045a9808322be155e67f022212a