### PR TITLE
chore: cache dependency-check data

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -40,6 +40,20 @@ jobs:
           cache: 'npm'
           cache-dependency-path: './frontend/package-lock.json'
 
+      - name: Get Dependency Check version
+        if: matrix.service == 'backend'
+        id: dc-version
+        run: |
+          version=$(grep -oP "org\\.owasp\\.dependencycheck' version '\\K[0-9.]+" build.gradle)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Dependency Check data
+        if: matrix.service == 'backend'
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/dependency-check-data
+          key: dependency-check-${{ steps.dc-version.outputs.version }}
+
       - name: Run dependency vulnerability scan
         if: matrix.service == 'backend'
         run: ./gradlew dependencyCheckAnalyze


### PR DESCRIPTION
## Summary
- cache Dependency Check data in workflow
- key cache by plugin version

## Testing
- `/tmp/actionlint-bin/actionlint .github/workflows/dependency-scan.yml`
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_689303727f548322a8899a9e9924cc9c