### PR TITLE
chore: add manual integration tests workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,10 +8,6 @@ concurrency:
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
 
 jobs:
   integration-tests:


### PR DESCRIPTION
## Summary
- run integration tests in separate workflow triggered manually

## Testing
- `yamllint -d '{extends: default, rules: {truthy: disable}}' .github/workflows/integration-tests.yml`


------
https://chatgpt.com/codex/tasks/task_e_68930b089c80832285527bdc0ccc1fe3