### PR TITLE
ci: pass secrets to docker compose without env files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,22 +35,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Create production .env file
+      - name: Build Docker images
         env:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD || 'changeme123!' }}
           ELASTIC_PASSWORD: ${{ secrets.ELASTIC_PASSWORD || 'changeMe123!' }}
           KIBANA_PASSWORD: ${{ secrets.KIBANA_PASSWORD || 'changeme123!' }}
           GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD || 'admin' }}
-        run: envsubst < infra/docker/compose/.env.ci > infra/docker/compose/.env
-
-      - name: Build Docker images
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: infra/docker/compose/docker-compose.yml
-          load: true
-          cache-from: type=gha,scope=deploy
-          cache-to: type=gha,mode=max,scope=deploy
+        run: |
+          docker compose -f infra/docker/compose/docker-compose.yml \
+            --env-file <(printf "POSTGRES_PASSWORD=%s\nELASTIC_PASSWORD=%s\nKIBANA_PASSWORD=%s\nGRAFANA_ADMIN_PASSWORD=%s\n" "$POSTGRES_PASSWORD" "$ELASTIC_PASSWORD" "$KIBANA_PASSWORD" "$GRAFANA_ADMIN_PASSWORD"; tail -n +5 infra/docker/compose/.env.ci) \
+            build
 
       - name: Deploy to ${{ github.event.inputs.environment }}
         run: echo "Deploying to ${{ github.event.inputs.environment }} environment"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -41,17 +41,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Prepare environment for validation
-        shell: bash
+      - name: Validate Docker Compose
         env:
           POSTGRES_PASSWORD: test_password_123
           GRAFANA_ADMIN_PASSWORD: test_password_123
           ELASTIC_PASSWORD: test_password_123
           KIBANA_PASSWORD: test_password_123
-        run: envsubst < infra/docker/compose/.env.ci > infra/docker/compose/.env
-
-      - name: Validate Docker Compose
-        run: docker compose -f infra/docker/compose/docker-compose.yml --env-file infra/docker/compose/.env config --quiet
+        run: |
+          docker compose -f infra/docker/compose/docker-compose.yml \
+            --env-file <(printf "POSTGRES_PASSWORD=%s\nGRAFANA_ADMIN_PASSWORD=%s\nELASTIC_PASSWORD=%s\nKIBANA_PASSWORD=%s\n" "$POSTGRES_PASSWORD" "$GRAFANA_ADMIN_PASSWORD" "$ELASTIC_PASSWORD" "$KIBANA_PASSWORD"; tail -n +5 infra/docker/compose/.env.ci) \
+            config --quiet
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@v2


### PR DESCRIPTION
## Summary
- avoid persisting secret-filled env files in deploy workflow
- feed env vars directly to docker compose in workflow linter

## Testing
- `./bin/actionlint .github/workflows/deploy.yml .github/workflows/workflow-lint.yml`

------
https://chatgpt.com/codex/tasks/task_e_689336dbe7bc8322955974d4b949ecfc