### PR TITLE
Use dotenv action for environment variables in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,15 +35,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker images
+      - uses: dotenvx/dotenv-action@v2
+        with:
+          path: infra/docker/compose/.env.ci
         env:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD || 'changeme123!' }}
           ELASTIC_PASSWORD: ${{ secrets.ELASTIC_PASSWORD || 'changeMe123!' }}
           KIBANA_PASSWORD: ${{ secrets.KIBANA_PASSWORD || 'changeme123!' }}
           GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD || 'admin' }}
+
+      - name: Build Docker images
         run: |
           docker compose -f infra/docker/compose/docker-compose.yml \
-            --env-file <(printf "POSTGRES_PASSWORD=%s\nELASTIC_PASSWORD=%s\nKIBANA_PASSWORD=%s\nGRAFANA_ADMIN_PASSWORD=%s\n" "$POSTGRES_PASSWORD" "$ELASTIC_PASSWORD" "$KIBANA_PASSWORD" "$GRAFANA_ADMIN_PASSWORD"; tail -n +5 infra/docker/compose/.env.ci) \
             build
 
       - name: Deploy to ${{ github.event.inputs.environment }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,8 +34,9 @@ jobs:
         run: |
           ./gradlew build -x test
 
-      - name: Prepare test environment
-        run: envsubst < infra/docker/compose/.env.ci > infra/docker/compose/.env
+      - uses: dotenvx/dotenv-action@v2
+        with:
+          path: infra/docker/compose/.env.ci
 
       - name: Start infrastructure services
         run: |

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -41,15 +41,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Validate Docker Compose
+      - uses: dotenvx/dotenv-action@v2
+        with:
+          path: infra/docker/compose/.env.ci
         env:
           POSTGRES_PASSWORD: test_password_123
           GRAFANA_ADMIN_PASSWORD: test_password_123
           ELASTIC_PASSWORD: test_password_123
           KIBANA_PASSWORD: test_password_123
+
+      - name: Validate Docker Compose
         run: |
           docker compose -f infra/docker/compose/docker-compose.yml \
-            --env-file <(printf "POSTGRES_PASSWORD=%s\nGRAFANA_ADMIN_PASSWORD=%s\nELASTIC_PASSWORD=%s\nKIBANA_PASSWORD=%s\n" "$POSTGRES_PASSWORD" "$GRAFANA_ADMIN_PASSWORD" "$ELASTIC_PASSWORD" "$KIBANA_PASSWORD"; tail -n +5 infra/docker/compose/.env.ci) \
             config --quiet
 
       - name: Run ShellCheck


### PR DESCRIPTION
## Summary
- load environment variables with dotenvx action
- simplify docker compose calls by removing envsubst and env-file options

## Testing
- `./gradlew test` *(fails: package javax.validation does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68933cf979648322af68a425bc269ba7