### PR TITLE
chore: enforce secret configuration

### DIFF
--- a/backend-crew/backend-crew-service/src/main/resources/application-docker.yml
+++ b/backend-crew/backend-crew-service/src/main/resources/application-docker.yml
@@ -6,10 +6,6 @@ spring:
     name: crew-service
   config:
     import: classpath:db-common.yml
-  datasource:
-    url: jdbc:postgresql://postgres:5432/aquastream_db
-    username: postgres
-    password: postgres
   kafka:
     bootstrap-servers: kafka:9092
 

--- a/backend-crew/backend-crew-service/src/main/resources/application.yml
+++ b/backend-crew/backend-crew-service/src/main/resources/application.yml
@@ -6,8 +6,8 @@ spring:
     name: crew-service
   datasource:
     url: jdbc:postgresql://localhost:5432/aquastream_db
-    username: postgres
-    password: postgres
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
 eureka:

--- a/backend-event/backend-event-service/src/main/resources/application-docker.yml
+++ b/backend-event/backend-event-service/src/main/resources/application-docker.yml
@@ -6,10 +6,6 @@ spring:
     name: event-service
   config:
     import: classpath:db-common.yml
-  datasource:
-    url: jdbc:postgresql://postgres:5432/aquastream_db
-    username: postgres
-    password: postgres
   kafka:
     bootstrap-servers: kafka:9092
     producer:

--- a/backend-event/backend-event-service/src/main/resources/application.yml
+++ b/backend-event/backend-event-service/src/main/resources/application.yml
@@ -6,8 +6,8 @@ spring:
     name: event-service
   datasource:
     url: jdbc:postgresql://localhost:5432/aquastream_db
-    username: postgres
-    password: postgres
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
   kafka:
     bootstrap-servers: localhost:9092

--- a/backend-gateway/backend-gateway-service/bin/main/application-docker.yml
+++ b/backend-gateway/backend-gateway-service/bin/main/application-docker.yml
@@ -6,11 +6,6 @@ spring:
     name: crew-service
   config:
     import: classpath:db-common.yml
-  datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/aquastream_db}
-    username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
-    driver-class-name: org.postgresql.Driver
 management:
   endpoints:
     web:

--- a/backend-gateway/backend-gateway-service/bin/main/application.yml
+++ b/backend-gateway/backend-gateway-service/bin/main/application.yml
@@ -7,7 +7,7 @@ spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/aquastream_gateway
     username: ${POSTGRES_USER:postgres}
-    password: ${POSTGRES_PASSWORD:postgres}
+    password: ${POSTGRES_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: none

--- a/backend-gateway/backend-gateway-service/src/main/resources/application.yml
+++ b/backend-gateway/backend-gateway-service/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/aquastream_db
     username: ${POSTGRES_USER:postgres}
-    password: ${POSTGRES_PASSWORD:postgres}
+    password: ${POSTGRES_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: none

--- a/backend-notification/backend-notification-service/src/main/resources/application.yml
+++ b/backend-notification/backend-notification-service/src/main/resources/application.yml
@@ -6,8 +6,8 @@ spring:
     name: notification-service
   datasource:
     url: jdbc:postgresql://localhost:5432/aquastream_db
-    username: postgres
-    password: postgres
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
   kafka:
     bootstrap-servers: localhost:9092

--- a/backend-user/README.md
+++ b/backend-user/README.md
@@ -36,14 +36,14 @@ Swagger UI: `http://localhost:8081/swagger-ui.html` (через Gateway — `/us
 ```bash
 curl -X POST http://localhost:8081/api/auth/login \
  -H 'Content-Type: application/json' \
- -d '{"username":"john_doe","password":"password123"}'
+-d '{"username":"john_doe","password":"<password>"}'
 ```
 
 Пример регистрации:
 ```bash
 curl -X POST http://localhost:8081/api/auth/register \
  -H 'Content-Type: application/json' \
- -d '{"username":"john_doe","name":"Джон Доу","password":"password123"}'
+-d '{"username":"john_doe","name":"Джон Доу","password":"<password>"}'
 ```
 
 ## Тестирование

--- a/backend-user/backend-user-service/bin/main/application-docker.yml
+++ b/backend-user/backend-user-service/bin/main/application-docker.yml
@@ -6,10 +6,6 @@ spring:
     name: user-service
   config:
     import: classpath:db-common.yml
-  datasource:
-    url: jdbc:postgresql://postgres:5432/aquastream_db
-    username: postgres
-    password: postgres
   kafka:
     bootstrap-servers: kafka:9092
 

--- a/backend-user/backend-user-service/bin/main/application.yml
+++ b/backend-user/backend-user-service/bin/main/application.yml
@@ -7,8 +7,8 @@ spring:
   datasource:
     # Для локального запуска подключаемся к базе на localhost
     url: jdbc:postgresql://localhost:5432/aquastream_db
-    username: postgres
-    password: postgres
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:

--- a/backend-user/backend-user-service/src/main/java/org/aquastream/user/dto/request/LoginRequest.java
+++ b/backend-user/backend-user-service/src/main/java/org/aquastream/user/dto/request/LoginRequest.java
@@ -12,6 +12,6 @@ public class LoginRequest {
     private String username;
 
     @NotBlank
-    @Schema(description = "Пароль пользователя", example = "password123")
+    @Schema(description = "Пароль пользователя", example = "<password>")
     private String password;
 } 

--- a/backend-user/backend-user-service/src/main/java/org/aquastream/user/dto/request/SignupRequest.java
+++ b/backend-user/backend-user-service/src/main/java/org/aquastream/user/dto/request/SignupRequest.java
@@ -20,7 +20,7 @@ public class SignupRequest {
     
     @NotBlank
     @Size(min = 6, max = 40)
-    @Schema(description = "Пароль пользователя", example = "password123")
+    @Schema(description = "Пароль пользователя", example = "<password>")
     private String password;
     
     @Schema(description = "Имя пользователя в Telegram без символа @", example = "ivan_ivanov")

--- a/backend-user/backend-user-service/src/main/resources/application-docker.yml
+++ b/backend-user/backend-user-service/src/main/resources/application-docker.yml
@@ -6,10 +6,6 @@ spring:
     name: user-service
   config:
     import: classpath:db-common.yml
-  datasource:
-    url: jdbc:postgresql://postgres:5432/aquastream_db
-    username: postgres
-    password: postgres
   kafka:
     bootstrap-servers: kafka:9092
 

--- a/backend-user/backend-user-service/src/main/resources/application.yml
+++ b/backend-user/backend-user-service/src/main/resources/application.yml
@@ -7,8 +7,8 @@ spring:
   datasource:
     # Для локального запуска подключаемся к базе на localhost
     url: jdbc:postgresql://localhost:5432/aquastream_db
-    username: postgres
-    password: postgres
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:

--- a/common/bin/main/db-common.yml
+++ b/common/bin/main/db-common.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/aquastream_db}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:

--- a/common/src/main/resources/db-common.yml
+++ b/common/src/main/resources/db-common.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://postgres:5432/aquastream_db}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:

--- a/infra/README.md
+++ b/infra/README.md
@@ -64,7 +64,7 @@ infra/
 
 ### 🔐 Авторизация
 - **Мониторинг** (Basic Auth): `admin:monitoring123`
-- **Elasticsearch**: `elastic:changeMe123!`
+- **Elasticsearch**: `elastic:<ELASTIC_PASSWORD>`
 - **Grafana**: `admin:admin`
 
 ### 🛠️ Для разработки (прямой доступ)

--- a/infra/docs/ELASTICSEARCH_SECURITY.md
+++ b/infra/docs/ELASTICSEARCH_SECURITY.md
@@ -9,12 +9,12 @@ Elasticsearch теперь настроен с включенной безопа
 
 ### Elasticsearch
 - **Пользователь**: `elastic`
-- **Пароль**: `changeMe123!` (настраивается в `.env` как `ELASTIC_PASSWORD` или через переменную окружения при запуске `./run.sh --use-env`)
+- **Пароль**: `<ELASTIC_PASSWORD>` (настраивается в `.env` как `ELASTIC_PASSWORD` или через переменную окружения при запуске `./run.sh --use-env`)
 - **URL**: ~~`https://localhost:9200`~~ → **Доступ через Nginx Reverse Proxy**
 
 ### Kibana
 - **Пользователь**: `kibana_system`
-- **Пароль**: `kibanaUser123!` (настраивается в `.env` как `KIBANA_PASSWORD` или через переменную окружения при запуске `./run.sh --use-env`)
+- **Пароль**: `<KIBANA_PASSWORD>` (настраивается в `.env` как `KIBANA_PASSWORD` или через переменную окружения при запуске `./run.sh --use-env`)
 - **URL**: ~~`https://localhost:5601`~~ → **Доступ через Nginx**: `https://localhost/monitoring/kibana/`
 - **Basic Auth**: admin:monitoring123 (для доступа через Nginx)
 
@@ -30,13 +30,13 @@ Elasticsearch теперь настроен с включенной безопа
 ### Curl команды
 ```bash
 # Проверка здоровья кластера
-curl -k -u elastic:changeMe123! https://localhost:9200/_cluster/health
+curl -k -u elastic:<ELASTIC_PASSWORD> https://localhost:9200/_cluster/health
 
 # Получение информации о кластере
-curl -k -u elastic:changeMe123! https://localhost:9200/
+curl -k -u elastic:<ELASTIC_PASSWORD> https://localhost:9200/
 
 # Просмотр индексов
-curl -k -u elastic:changeMe123! https://localhost:9200/_cat/indices?v
+curl -k -u elastic:<ELASTIC_PASSWORD> https://localhost:9200/_cat/indices?v
 ```
 
 ### С использованием CA сертификата
@@ -45,7 +45,7 @@ curl -k -u elastic:changeMe123! https://localhost:9200/_cat/indices?v
 docker cp aquastream-elasticsearch-setup-1:/usr/share/elasticsearch/config/certs/ca/ca.crt ./ca.crt
 
 # Использовать CA сертификат
-curl --cacert ca.crt -u elastic:changeMe123! https://localhost:9200/_cluster/health
+curl --cacert ca.crt -u elastic:<ELASTIC_PASSWORD> https://localhost:9200/_cluster/health
 ```
 
 ## Конфигурация компонентов

--- a/infra/docs/INFRASTRUCTURE_VALIDATION.md
+++ b/infra/docs/INFRASTRUCTURE_VALIDATION.md
@@ -293,10 +293,10 @@ image: nginx:1.25-alpine
 ```bash
 # Используйте сильные пароли (≥12 символов)
 # Плохо
-POSTGRES_PASSWORD=123456
+POSTGRES_PASSWORD=<WEAK_PASSWORD>
 
 # Хорошо
-POSTGRES_PASSWORD=MySecurePassword123!
+POSTGRES_PASSWORD=<STRONG_PASSWORD>
 ```
 
 ### ⚠️ "Shell скрипт не исполняемый"

--- a/infra/docs/system-analysis/crew/tech-notes.md
+++ b/infra/docs/system-analysis/crew/tech-notes.md
@@ -10,7 +10,7 @@ spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/aquastream
     username: postgres
-    password: postgres
+    password: ${SPRING_DATASOURCE_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: validate

--- a/infra/docs/system-analysis/event/backend-event/business-requirements.md
+++ b/infra/docs/system-analysis/event/backend-event/business-requirements.md
@@ -2344,7 +2344,7 @@ services:
       - "5432:5432"
     environment:
       POSTGRES_USER: event_service
-      POSTGRES_PASSWORD: event_password
+      POSTGRES_PASSWORD: <EVENT_DB_PASSWORD>
       POSTGRES_DB: event_db
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -2420,7 +2420,7 @@ services:
       SPRING_PROFILES_ACTIVE: dev
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/event_db
       SPRING_DATASOURCE_USERNAME: event_service
-      SPRING_DATASOURCE_PASSWORD: event_password
+      SPRING_DATASOURCE_PASSWORD: <EVENT_DB_PASSWORD>
       SPRING_REDIS_HOST: redis
       SPRING_REDIS_PORT: 6379
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
@@ -2497,7 +2497,7 @@ docker-compose -f docker/docker-compose.yml up -d postgres redis kafka zookeeper
 4. **Подключение к базе данных**:
    - Установите DBeaver (если еще не установлен)
    - Создайте новое соединение PostgreSQL
-   - Укажите параметры: `localhost:5432/event_db`, пользователь: `event_service`, пароль: `event_password`
+   - Укажите параметры: `localhost:5432/event_db`, пользователь: `event_service`, пароль: `<EVENT_DB_PASSWORD>`
 
 5. **Запуск из IDE**:
    - Найдите класс `EventServiceApplication.java` в модуле backend-event-service
@@ -2602,7 +2602,7 @@ docker-compose -f docker/docker-compose.yml exec kafka kafka-console-consumer --
 1. **Подключение к базе данных**:
    - Создайте новое соединение PostgreSQL в DBeaver
    - Используйте хост `localhost`, порт `5432`, база `event_db`
-   - Логин: `event_service`, пароль: `event_password`
+   - Логин: `event_service`, пароль: `<EVENT_DB_PASSWORD>`
 
 2. **Полезные действия**:
    - SQL-скрипты можно сохранять в проекте в папке `scripts`

--- a/infra/docs/system-analysis/frontend/testing-strategy.md
+++ b/infra/docs/system-analysis/frontend/testing-strategy.md
@@ -84,7 +84,7 @@ describe('LoginForm integration', () => {
     });
     
     fireEvent.change(screen.getByLabelText(/пароль/i), {
-      target: { value: 'password123' }
+      target: { value: '<password>' }
     });
     
     fireEvent.click(screen.getByRole('button', { name: /войти/i }));
@@ -92,7 +92,7 @@ describe('LoginForm integration', () => {
     await waitFor(() => {
       expect(mockSubmit).toHaveBeenCalledWith({
         email: 'test@example.com',
-        password: 'password123'
+        password: '<password>'
       });
     });
   });
@@ -133,7 +133,7 @@ test('user can login successfully', async ({ page }) => {
   
   // Заполняем форму
   await page.getByLabel(/Email/).fill('test@example.com');
-  await page.getByLabel(/Пароль/).fill('password123');
+  await page.getByLabel(/Пароль/).fill('<password>');
   await page.getByRole('button', { name: /Войти/ }).click();
   
   // Проверяем, что после успешного входа происходит редирект

--- a/infra/monitoring/alertmanager/alertmanager.yml
+++ b/infra/monitoring/alertmanager/alertmanager.yml
@@ -6,8 +6,8 @@ global:
   smtp_smarthost: 'smtp.gmail.com:587'
   smtp_from: 'alerts@aquastream.company.com'
   smtp_auth_username: 'alerts@aquastream.company.com'
-  smtp_auth_password: 'your-app-password'  # Используйте переменные окружения!
-  smtp_auth_secret: 'your-app-password'
+  smtp_auth_password: '${SMTP_AUTH_PASSWORD}'  # Используйте переменные окружения!
+  smtp_auth_secret: '${SMTP_AUTH_PASSWORD}'
   smtp_require_tls: true
 
   # Slack настройки (глобальные)

--- a/infra/monitoring/prometheus/prometheus.yml
+++ b/infra/monitoring/prometheus/prometheus.yml
@@ -78,7 +78,7 @@ scrape_configs:
       - targets: ['elasticsearch:9200']
     basic_auth:
       username: 'elastic'
-      password: 'changeMe123!'
+      password: '${ELASTIC_PASSWORD}'
     scheme: https
     tls_config:
       insecure_skip_verify: true

--- a/infra/security/PASSWORD-SECURITY.md
+++ b/infra/security/PASSWORD-SECURITY.md
@@ -6,10 +6,10 @@
 
 **Все слабые пароли заменены на криптографически стойкие:**
 
-- ❌ `POSTGRES_PASSWORD=postgres` → ✅ `KFFrzGlktp9qKOfns9SOxsCD1Y4hGeKh`
-- ❌ `GRAFANA_ADMIN_PASSWORD=admin` → ✅ `HgAuq//ATCB2d6kLXtyekLJr8dA=`
-- ❌ `ELASTIC_PASSWORD=changeMe123!` → ✅ `8JWQCXJNJ5CuMMeJfXZgIMgivWPgPZNNIYdXyw==`
-- ❌ `KIBANA_PASSWORD=kibanaUser123!` → ✅ `cVp84BasRpgB/1F/jqifMmSZoiwDjAAq`
+- ❌ `POSTGRES_PASSWORD=postgres` → ✅ `<STRONG_PASSWORD>`
+- ❌ `GRAFANA_ADMIN_PASSWORD=admin` → ✅ `<STRONG_PASSWORD>`
+- ❌ `ELASTIC_PASSWORD=changeMe123!` → ✅ `<STRONG_PASSWORD>`
+- ❌ `KIBANA_PASSWORD=kibanaUser123!` → ✅ `<STRONG_PASSWORD>`
 
 ## 🛠️ Инструменты Управления Паролями
 
@@ -71,8 +71,8 @@ docker compose -f docker-compose.secrets.yml up -d
 
 ```bash
 # infra/docker/compose/.env
-POSTGRES_PASSWORD=KFFrzGlktp9qKOfns9SOxsCD1Y4hGeKh
-GRAFANA_ADMIN_PASSWORD=HgAuq//ATCB2d6kLXtyekLJr8dA=
+POSTGRES_PASSWORD=<STRONG_PASSWORD>
+GRAFANA_ADMIN_PASSWORD=<STRONG_PASSWORD>
 ```
 
 **Плюсы:**


### PR DESCRIPTION
## Summary
- remove hard-coded password fallbacks from service configs
- fail early when required secrets are missing
- use environment variables for monitoring credentials

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68935243eb648322ab79a0ec85c4453b