### PR TITLE
chore: centralize Java and Node setup in workflows

### DIFF
--- a/.github/actions/setup-java-node/action.yml
+++ b/.github/actions/setup-java-node/action.yml
@@ -1,0 +1,27 @@
+name: 'Setup Java and Node'
+description: 'Set up Temurin JDK and Node.js with caching'
+inputs:
+  java-version:
+    description: 'Java version'
+    default: '21'
+  node-version:
+    description: 'Node.js version'
+    default: '20'
+  node-cache-dependency-path:
+    description: 'Path to dependency file for Node caching'
+    default: './frontend/package-lock.json'
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: 'temurin'
+        cache: 'gradle'
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: ${{ inputs.node-cache-dependency-path }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -34,12 +34,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - name: Set up Java and Node.js
+        uses: ./.github/actions/setup-java-node
 
       - name: Build JARs
         run: ./gradlew build

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -24,21 +24,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
-        if: matrix.service == 'backend'
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'gradle'
-
-      - name: Setup Node.js
-        if: matrix.service == 'frontend'
-        uses: actions/setup-node@v4
+      - name: Set up Java and Node.js
+        uses: ./.github/actions/setup-java-node
         with:
           node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: './frontend/package-lock.json'
 
       - name: Get Dependency Check version
         if: matrix.service == 'backend'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -31,12 +31,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: './frontend/package-lock.json'
+      - name: Set up Java and Node.js
+        uses: ./.github/actions/setup-java-node
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,12 +23,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - name: Set up Java and Node.js
+        uses: ./.github/actions/setup-java-node
 
       - name: Build application
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,12 +28,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - name: Set up Java and Node.js
+        uses: ./.github/actions/setup-java-node
 
       - name: Build backend modules
         run: |
@@ -68,21 +64,8 @@ jobs:
           key: trivy-db-${{ runner.os }}
           restore-keys: trivy-db-
 
-      - name: Set up JDK 21
-        if: matrix.service != 'frontend'
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'gradle'
-
-      - name: Set up Node.js
-        if: matrix.service == 'frontend'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: 'frontend/package-lock.json'
+      - name: Set up Java and Node.js
+        uses: ./.github/actions/setup-java-node
 
       - name: Download backend JARs
         if: matrix.service != 'frontend'


### PR DESCRIPTION
## Summary
- add composite GitHub Action to configure Java 21 and Node.js with caching
- replace individual setup steps in CI workflows with the new action

## Testing
- `npm test --prefix frontend`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68935e65a4fc83229b3c060199f8ebb0