### PR TITLE
feat(ci): cache docker builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,8 +47,10 @@ jobs:
 
         - name: Build Docker images
           run: |
-            docker compose -f infra/docker/compose/docker-compose.yml \
-              build
+            docker buildx bake -f infra/docker/compose/docker-compose.yml \
+              --set *.cache-from=type=gha \
+              --set *.cache-to=type=gha,mode=max \
+              --load
 
         - name: Deploy to ${{ github.event.inputs.environment }}
           run: >


### PR DESCRIPTION
## Summary
- use buildx bake with GHA cache in deploy workflow

## Testing
- `./gradlew test` *(fails: interrupted after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_689363769d0c8322ad057392631367b2