### PR TITLE
chore: centralize datasource config

### DIFF
--- a/backend-crew/backend-crew-service/src/main/resources/application.yml
+++ b/backend-crew/backend-crew-service/src/main/resources/application.yml
@@ -30,8 +30,6 @@ spring:
   config:
     activate:
       on-profile: local
-  datasource:
-    url: jdbc:postgresql://localhost:5432/aquastream_db
 eureka:
   client:
     service-url:
@@ -43,8 +41,6 @@ spring:
   config:
     activate:
       on-profile: docker
-  datasource:
-    url: jdbc:postgresql://postgres:5432/aquastream_db
 eureka:
   client:
     service-url:

--- a/backend-event/backend-event-service/src/main/resources/application.yml
+++ b/backend-event/backend-event-service/src/main/resources/application.yml
@@ -82,8 +82,6 @@ spring:
   config:
     activate:
       on-profile: local
-  datasource:
-    url: jdbc:postgresql://localhost:5432/aquastream_db
   kafka:
     bootstrap-servers: localhost:9092
 eureka:
@@ -97,8 +95,6 @@ spring:
   config:
     activate:
       on-profile: docker
-  datasource:
-    url: jdbc:postgresql://postgres:5432/aquastream_db
   kafka:
     bootstrap-servers: kafka:9092
 eureka:

--- a/backend-gateway/backend-gateway-service/src/main/resources/application.yml
+++ b/backend-gateway/backend-gateway-service/src/main/resources/application.yml
@@ -97,8 +97,6 @@ spring:
   config:
     activate:
       on-profile: local
-  datasource:
-    url: jdbc:postgresql://localhost:5432/aquastream_db
 eureka:
   client:
     serviceUrl:
@@ -110,8 +108,6 @@ spring:
   config:
     activate:
       on-profile: docker
-  datasource:
-    url: jdbc:postgresql://postgres:5432/aquastream_db
 eureka:
   client:
     serviceUrl:

--- a/backend-notification/backend-notification-service/src/main/resources/application.yml
+++ b/backend-notification/backend-notification-service/src/main/resources/application.yml
@@ -19,8 +19,6 @@ spring:
   config:
     activate:
       on-profile: local
-  datasource:
-    url: jdbc:postgresql://localhost:5432/aquastream_db
   kafka:
     bootstrap-servers: localhost:9092
 server:
@@ -30,8 +28,6 @@ spring:
   config:
     activate:
       on-profile: docker
-  datasource:
-    url: jdbc:postgresql://postgres:5432/aquastream_db
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
 server:

--- a/backend-user/backend-user-service/src/main/resources/application.yml
+++ b/backend-user/backend-user-service/src/main/resources/application.yml
@@ -54,8 +54,6 @@ spring:
   config:
     activate:
       on-profile: local
-  datasource:
-    url: jdbc:postgresql://localhost:5432/aquastream_db
   kafka:
     bootstrap-servers: localhost:9092
 eureka:
@@ -69,8 +67,6 @@ spring:
   config:
     activate:
       on-profile: docker
-  datasource:
-    url: jdbc:postgresql://postgres:5432/aquastream_db
   kafka:
     bootstrap-servers: kafka:9092
 eureka:

--- a/infra/docker/compose/.env.example
+++ b/infra/docker/compose/.env.example
@@ -32,6 +32,11 @@ GRAFANA_ADMIN_PASSWORD=              # REQUIRED: Strong password for Grafana adm
 ELASTIC_PASSWORD=                    # REQUIRED: Strong password for Elasticsearch
 KIBANA_PASSWORD=                     # REQUIRED: Strong password for Kibana user
 
+# Spring datasource defaults for development
+SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/aquastream_db
+SPRING_DATASOURCE_USERNAME=postgres
+SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+
 # Ports (host-facing) - через Nginx reverse proxy
 NGINX_HTTP_PORT=80
 NGINX_HTTPS_PORT=443

--- a/infra/docker/compose/docker-compose.dev.yml
+++ b/infra/docker/compose/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+# Development overrides for datasource configuration
+x-spring-datasource: &spring-datasource
+  SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
+  SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+  SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+
+services:
+  user-service:
+    environment:
+      <<: *spring-datasource
+  crew-service:
+    environment:
+      <<: *spring-datasource
+  event-service:
+    environment:
+      <<: *spring-datasource
+  notification-service:
+    environment:
+      <<: *spring-datasource
+  api-gateway:
+    environment:
+      <<: *spring-datasource


### PR DESCRIPTION
## Summary
- use shared db-common.yml across services and drop duplicated datasource URLs
- add dev datasource defaults to example env and compose override

## Testing
- `./gradlew test` *(fails: Execution failed for task ':backend-user:backend-user-service:test')*

------
https://chatgpt.com/codex/tasks/task_e_68939b4081ec8322b5ad61fac5433c69