### PR TITLE
docs: document monitoring stack and secrets usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,15 @@ npm ci && npm run build
 
 ### 2. Запуск через Docker
 
-В каталоге `infra/docker/compose` доступны два файла:
-- `docker-compose.dev.yml` — лёгкая конфигурация для разработки.
-- `docker-compose.full.yml` — полный стек со всеми инфраструктурными компонентами.
+В каталоге `infra/docker/compose` доступны основные файлы:
+- `docker-compose.dev.yml` — основная конфигурация для разработки.
+- `docker-compose.secrets.yml` — production-шаблон, используется только в CI/CD.
+
+Мониторинг можно поднять отдельным стеком при необходимости:
+
+```bash
+docker compose -f infra/monitoring/docker-compose.monitoring.yml up -d
+```
 
 1. **Установка Docker и Docker Compose:**
    Убедитесь, что на вашем компьютере установлены Docker и Docker Compose.

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,9 +4,15 @@
 
 Этот каталог содержит инфраструктурную конфигурацию платформы AquaStream, включая Docker, мониторинг и конфигурации развертывания с усиленной безопасностью.
 
-В `docker/compose` находятся два файла:
+В `docker/compose` находятся ключевые файлы:
 - `docker-compose.dev.yml` — минимальный набор сервисов для разработки;
-- `docker-compose.full.yml` — полный стек с мониторингом и прочей инфраструктурой.
+- `docker-compose.secrets.yml` — production-шаблон, используется только в CI/CD.
+
+Мониторинг запускается отдельным стеком при необходимости:
+
+```bash
+docker compose -f infra/monitoring/docker-compose.monitoring.yml up -d
+```
 
 ## Архитектура
 
@@ -22,14 +28,15 @@ Internet → Nginx (HTTPS) → Internal Docker Network → Microservices
 infra/
 ├── docker/
 │   ├── compose/
-│   │   ├── docker-compose.dev.yml  # Лёгкая конфигурация для разработки
-│   │   ├── docker-compose.full.yml # Полный стек со всеми сервисами
+│   │   ├── docker-compose.dev.yml      # Лёгкая конфигурация для разработки
+│   │   ├── docker-compose.secrets.yml  # Шаблон production-конфигурации (CI/CD)
 │   │   └── .env                    # Переменные окружения
 │   └── images/
 │       ├── Dockerfile.nginx        # Reverse proxy
 │       ├── Dockerfile.backend      # Общий Dockerfile для микросервисов
 │       └── Dockerfile.frontend     # Веб-интерфейс
 ├── monitoring/
+│   ├── docker-compose.monitoring.yml # Опциональный стек мониторинга
 │   ├── nginx/                      # Конфигурация Nginx
 │   ├── grafana/                    # Дашборды мониторинга
 │   ├── prometheus/                 # Сбор метрик

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -15,9 +15,7 @@ This monitoring stack provides:
 ### 1. Start Monitoring Stack
 
 ```bash
-# From the monitoring directory
-cd infra/monitoring
-docker-compose -f docker-compose.monitoring.yml up -d
+docker compose -f infra/monitoring/docker-compose.monitoring.yml up -d
 ```
 
 ### 2. Access Services
@@ -30,7 +28,7 @@ docker-compose -f docker-compose.monitoring.yml up -d
 
 ```bash
 # Start all services with monitoring enabled
-docker-compose up -d
+docker compose -f infra/docker/compose/docker-compose.dev.yml up -d
 ```
 
 ## 📊 Available Dashboards

--- a/infra/monitoring/docker-compose.monitoring.yml
+++ b/infra/monitoring/docker-compose.monitoring.yml
@@ -1,5 +1,5 @@
 # Docker Compose configuration for AquaStream monitoring stack
-# Run with: docker-compose -f docker-compose.monitoring.yml up -d
+# Run with: docker compose -f infra/monitoring/docker-compose.monitoring.yml up -d
 
 version: '3.8'
 


### PR DESCRIPTION
## Summary
- document optional monitoring stack and how to start it
- note docker-compose.secrets.yml is a CI/CD production template
- focus development instructions on docker-compose.dev.yml

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6893d33d6bd48322803e618b96fa3136