### PR TITLE
Add restart option to run script and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ cp infra/docker/compose/.env.example infra/docker/compose/.env
 ./run.sh lint -be    # Запуск линтера бэкенда
 ./run.sh lint -fe    # Запуск линтера фронтенда
 ./run.sh start       # Поднимает Docker-инфраструктуру
+./run.sh restart     # Перезапускает Docker-инфраструктуру
 ./run.sh logs        # Показывает логи контейнеров
 ./run.sh stop        # Останавливает и очищает окружение
 ```
@@ -141,6 +142,7 @@ npm ci && npm run build
 
 ```bash
 ./run.sh start  # Запуск контейнеров
+./run.sh restart  # Перезапуск контейнеров
 ./run.sh stop   # Остановка и очистка контейнеров
 ./run.sh logs   # Просмотр логов
 ```

--- a/run.sh
+++ b/run.sh
@@ -81,11 +81,15 @@ case "$1" in
   stop)
     run_cmd docker compose -f "$COMPOSE_FILE" down -v
     ;;
+  restart)
+    run_cmd "$0" stop
+    run_cmd "$0" start
+    ;;
   logs)
     run_cmd docker compose -f "$COMPOSE_FILE" logs -f
     ;;
   *)
-    echo "Usage: $0 {build|test|lint|start|stop|logs} [-be|-fe]"
+    echo "Usage: $0 {build|test|lint|start|stop|restart|logs} [-be|-fe]"
     exit 1
     ;;
 


### PR DESCRIPTION
## Summary
- add `restart` case to `run.sh` invoking `stop` then `start`
- document `./run.sh restart` usage in README

## Testing
- `bash -n run.sh`
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_6893d5d60c14832288164c878712f4b7