### PR TITLE
feat: add status command to run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ cp infra/docker/compose/.env.example infra/docker/compose/.env
 ./run.sh lint -fe    # Запуск линтера фронтенда
 ./run.sh start       # Поднимает Docker-инфраструктуру
 ./run.sh restart     # Перезапускает Docker-инфраструктуру
+./run.sh status      # Показывает статус контейнеров
 ./run.sh logs        # Показывает логи контейнеров
 ./run.sh stop        # Останавливает и очищает окружение
 ```

--- a/run.sh
+++ b/run.sh
@@ -85,11 +85,14 @@ case "$1" in
     run_cmd "$0" stop
     run_cmd "$0" start
     ;;
+  status)
+    run_cmd docker compose -f "$COMPOSE_FILE" ps
+    ;;
   logs)
     run_cmd docker compose -f "$COMPOSE_FILE" logs -f
     ;;
   *)
-    echo "Usage: $0 {build|test|lint|start|stop|restart|logs} [-be|-fe]"
+    echo "Usage: $0 {build|test|lint|start|stop|restart|status|logs} [-be|-fe]"
     exit 1
     ;;
 


### PR DESCRIPTION
## Summary
- add `status` command to run.sh to show compose stack
- document `./run.sh status`

## Testing
- `bash -n run.sh`
- `./run.sh status` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893d866fed08322befddbfac62a8e15