### PR TITLE
feat: add dev run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ cp infra/docker/compose/.env.example infra/docker/compose/.env
 ./run.sh lint        # Запуск линтеров всего проекта
 ./run.sh lint -be    # Запуск линтера бэкенда
 ./run.sh lint -fe    # Запуск линтера фронтенда
+./run.sh dev -be    # Запуск бэкенда с горячей перезагрузкой
+./run.sh dev -fe    # Запуск фронтенда в режиме разработки
 ./run.sh start       # Поднимает Docker-инфраструктуру
 ./run.sh restart     # Перезапускает Docker-инфраструктуру
 ./run.sh logs        # Показывает логи контейнеров

--- a/run.sh
+++ b/run.sh
@@ -71,6 +71,20 @@ case "$1" in
         ;;
     esac
     ;;
+  dev)
+    case "$2" in
+      -be)
+        run_cmd ./gradlew bootRun
+        ;;
+      -fe)
+        run_cmd npm --prefix frontend start
+        ;;
+      *)
+        echo "Usage: $0 dev [-be|-fe]"
+        exit 1
+        ;;
+    esac
+    ;;
   start)
     if [ ! -f "$ENV_FILE" ]; then
       cp "$ENV_EXAMPLE" "$ENV_FILE"
@@ -89,7 +103,7 @@ case "$1" in
     run_cmd docker compose -f "$COMPOSE_FILE" logs -f
     ;;
   *)
-    echo "Usage: $0 {build|test|lint|start|stop|restart|logs} [-be|-fe]"
+    echo "Usage: $0 {build|test|lint|dev|start|stop|restart|logs} [-be|-fe]"
     exit 1
     ;;
 


### PR DESCRIPTION
## Summary
- add `dev` command to `run.sh` for backend and frontend hot reload
- document `dev` usage in README

## Testing
- `./run.sh lint -be`
- `./run.sh dev -be` *(fails: Port 8080 was already in use)*
- `./run.sh dev -fe`


------
https://chatgpt.com/codex/tasks/task_e_6893da08b2ec83228d9ea70aa49deda0