### PR TITLE
Add lint and check commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ cp infra/docker/compose/.env.example infra/docker/compose/.env
 ./run.sh lint        # Запуск линтеров всего проекта
 ./run.sh lint -be    # Запуск линтера бэкенда
 ./run.sh lint -fe    # Запуск линтера фронтенда
+./run.sh check       # Запуск линтеров и тестов всего проекта
+./run.sh check -be   # Запуск линтеров и тестов бэкенда
+./run.sh check -fe   # Запуск линтеров и тестов фронтенда
 ./run.sh dev -be    # Запуск бэкенда с горячей перезагрузкой
 ./run.sh dev -fe    # Запуск фронтенда в режиме разработки
 ./run.sh build-containers # Сборка Docker образов

--- a/run.sh
+++ b/run.sh
@@ -71,6 +71,26 @@ case "$1" in
         ;;
     esac
     ;;
+  check)
+    case "$2" in
+      -be)
+        run_cmd ./gradlew check
+        ;;
+      -fe)
+        run_cmd npm --prefix frontend run lint
+        run_cmd npm --prefix frontend test
+        ;;
+      "")
+        run_cmd ./gradlew check
+        run_cmd npm --prefix frontend run lint
+        run_cmd npm --prefix frontend test
+        ;;
+      *)
+        echo "Usage: $0 check [-be|-fe]"
+        exit 1
+        ;;
+    esac
+    ;;
   dev)
       case "$2" in
         -be)
@@ -113,7 +133,7 @@ case "$1" in
     run_cmd docker compose -f "$COMPOSE_FILE" logs -f
     ;;
   *)
-    echo "Usage: $0 {build|test|lint|dev|build-containers|start|stop|restart|status|logs} [-be|-fe]"
+    echo "Usage: $0 {build|test|lint|check|dev|build-containers|start|stop|restart|status|logs} [-be|-fe]"
     exit 1
     ;;
 


### PR DESCRIPTION
## Summary
- add lint helper for backend and frontend
- introduce check command chaining linting and tests
- document lint and check usage in README

## Testing
- `./run.sh lint -fe`
- `./run.sh check`


------
https://chatgpt.com/codex/tasks/task_e_68944fb2884c8322988e306873938423