### PR TITLE
refactor: reuse staged file list in pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,6 +6,7 @@ set -euo pipefail
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 HOOK_DIR="$(dirname "$0")"
+CHANGED_FILES="$(git diff --cached --name-only)"
 
 # Цвета для вывода
 NC="\033[0m"; GREEN="\033[0;32m"; YELLOW="\033[0;33m"; RED="\033[0;31m"
@@ -24,20 +25,20 @@ log() {
 
 # Проверяем, есть ли изменения в инфраструктурных файлах
 has_infrastructure_changes() {
-    local changed_files
-    changed_files=$(git diff --cached --name-only)
-    
+    local changed_files="$1"
+
     echo "$changed_files" | grep -E "(docker-compose\.dev\.yml|docker-compose\.full\.yml|Dockerfile|\.env|nginx\.conf|prometheus\.yml|logstash\.conf|\.sh)$" >/dev/null
 }
 
 # Проверяем конкретные файлы на критичные ошибки
 check_critical_files() {
+    local changed_files="$1"
     local exit_code=0
-    
+
     # Проверяем docker-compose.dev.yml и docker-compose.full.yml если они изменились
     local compose_files=("docker-compose.dev.yml" "docker-compose.full.yml")
     for compose in "${compose_files[@]}"; do
-        if git diff --cached --name-only | grep -q "$compose"; then
+        if echo "$changed_files" | grep -q "$compose"; then
             log INFO "Проверка $compose..."
 
             local compose_file="$PROJECT_ROOT/infra/docker/compose/$compose"
@@ -65,12 +66,12 @@ check_critical_files() {
             fi
         fi
     done
-    
+
     # Проверяем .env файлы
-    if git diff --cached --name-only | grep -q "\.env"; then
+    if echo "$changed_files" | grep -q "\.env"; then
         log WARN "⚠️ Изменения в .env файле!"
         log WARN "Убедитесь, что чувствительные данные не попадают в репозиторий."
-        
+
         # Проверяем, что .env файл в .gitignore
         if [ -f "$PROJECT_ROOT/.gitignore" ]; then
             if ! grep -q "\.env" "$PROJECT_ROOT/.gitignore"; then
@@ -79,14 +80,14 @@ check_critical_files() {
             fi
         fi
     fi
-    
+
     # Проверяем shell скрипты
     local scripts_changed
-    scripts_changed=$(git diff --cached --name-only | grep "\.sh$" || true)
-    
+    scripts_changed=$(echo "$changed_files" | grep "\.sh$" || true)
+
     if [ -n "$scripts_changed" ]; then
         log INFO "Проверка shell скриптов..."
-        
+
         echo "$scripts_changed" | while read script; do
             if [ -f "$PROJECT_ROOT/$script" ]; then
                 # Проверка синтаксиса bash
@@ -94,7 +95,7 @@ check_critical_files() {
                     log ERROR "❌ Ошибка синтаксиса в $script!"
                     exit_code=1
                 fi
-                
+
                 # Проверка на исполняемые права
                 if [ ! -x "$PROJECT_ROOT/$script" ]; then
                     log WARN "⚠️ Скрипт $script не исполняемый. Исправляем..."
@@ -104,7 +105,7 @@ check_critical_files() {
             fi
         done
     fi
-    
+
     return $exit_code
 }
 
@@ -131,12 +132,13 @@ run_full_validation() {
 
 # Проверяем форматирование YAML файлов
 check_yaml_formatting() {
+    local changed_files="$1"
     local yaml_files
-    yaml_files=$(git diff --cached --name-only | grep -E "\.(yml|yaml)$" || true)
-    
+    yaml_files=$(echo "$changed_files" | grep -E "\.(yml|yaml)$" || true)
+
     if [ -n "$yaml_files" ] && command -v yq >/dev/null 2>&1; then
         log INFO "Проверка YAML форматирования..."
-        
+
         echo "$yaml_files" | while read yaml_file; do
             if [ -f "$PROJECT_ROOT/$yaml_file" ]; then
                 if ! yq eval '.' "$PROJECT_ROOT/$yaml_file" >/dev/null 2>&1; then
@@ -151,37 +153,37 @@ check_yaml_formatting() {
 # Основная логика pre-commit хука
 main() {
     log INFO "🚀 Запуск pre-commit валидации AquaStream"
-    
+
     # Если нет изменений в инфраструктурных файлах, пропускаем
-    if ! has_infrastructure_changes; then
+    if ! has_infrastructure_changes "$CHANGED_FILES"; then
         log INFO "ℹ️ Нет изменений в инфраструктурных файлах, пропускаем валидацию"
         exit 0
     fi
-    
+
     log INFO "📋 Найдены изменения в инфраструктурных файлах"
-    
+
     local exit_code=0
-    
+
     # Проверяем критичные файлы
-    if ! check_critical_files; then
+    if ! check_critical_files "$CHANGED_FILES"; then
         exit_code=1
     fi
-    
+
     # Проверяем YAML форматирование
-    if ! check_yaml_formatting; then
+    if ! check_yaml_formatting "$CHANGED_FILES"; then
         exit_code=1
     fi
-    
+
     # Запускаем полную валидацию только для серьезных изменений
     local major_files_changed
-    major_files_changed=$(git diff --cached --name-only | grep -E "(docker-compose\.dev\.yml|docker-compose\.full\.yml|Dockerfile)" || true)
-    
+    major_files_changed=$(echo "$CHANGED_FILES" | grep -E "(docker-compose\.dev\.yml|docker-compose\.full\.yml|Dockerfile)" || true)
+
     if [ -n "$major_files_changed" ]; then
         if ! run_full_validation; then
             exit_code=1
         fi
     fi
-    
+
     if [ $exit_code -eq 0 ]; then
         log INFO "✅ Все проверки пройдены! Коммит разрешен."
     else
@@ -195,7 +197,7 @@ main() {
         log INFO "🚫 Для пропуска проверок (НЕ РЕКОМЕНДУЕТСЯ):"
         log INFO "  • git commit --no-verify"
     fi
-    
+
     exit $exit_code
 }
 


### PR DESCRIPTION
## Summary
- compute list of staged files once and reuse
- pass changed files into infrastructure checks
- use staged file list to decide when to run full validation

## Testing
- `bash -n .githooks/pre-commit`
- `bash .githooks/pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_689451dcaec483229e5c26d731f1e9b3