### PR TITLE
Copy full repository for backend Docker builds

### DIFF
--- a/infra/docker/images/Dockerfile.backend
+++ b/infra/docker/images/Dockerfile.backend
@@ -7,17 +7,12 @@ ARG SERVICE
 FROM eclipse-temurin:${ECLIPSE_TEMURIN_JDK_TAG} AS build
 WORKDIR /workspace
 
-# Copy Gradle wrapper and settings
-COPY gradlew settings.gradle build.gradle version.properties /workspace/
-COPY gradle /workspace/gradle
-
-# Copy common module and selected service
-COPY common /workspace/common
-COPY $SERVICE /workspace/$SERVICE
+# Copy entire repository
+COPY . /workspace
 
 # Build jar for selected service
-RUN bash -c "./gradlew :${SERVICE//\//:}:bootJar --no-daemon --build-cache \
-    && cp \$(find $SERVICE/build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n1) app.jar"
+RUN ./gradlew :${SERVICE//\//:}:bootJar --no-daemon --build-cache \
+    && cp "$(find "${SERVICE}/build/libs" -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n1)" app.jar
 
 # --- Stage 2: runtime -----------------------------
 FROM eclipse-temurin:${ECLIPSE_TEMURIN_JRE_TAG} AS runtime


### PR DESCRIPTION
## Summary
- copy entire repository so Gradle can resolve all modules during backend image builds
- build specified service jar with Gradle wrapper

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `docker build -f infra/docker/images/Dockerfile.backend --build-arg SERVICE=backend-user/backend-user-service .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_6893e09f4f248322bb69230ee3bcc530