### PR TITLE
refactor: reuse staged file list

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,7 +5,7 @@ set -euo pipefail
 # Автоматически проверяет изменения в инфраструктурных файлах
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-HOOK_DIR="$(dirname "$0")"
+# Collect staged file names once for reuse across checks
 CHANGED_FILES="$(git diff --cached --name-only)"
 
 # Цвета для вывода
@@ -175,10 +175,7 @@ main() {
     fi
 
     # Запускаем полную валидацию только для серьезных изменений
-    local major_files_changed
-    major_files_changed=$(echo "$CHANGED_FILES" | grep -E "(docker-compose\.dev\.yml|docker-compose\.full\.yml|Dockerfile)" || true)
-
-    if [ -n "$major_files_changed" ]; then
+    if echo "$CHANGED_FILES" | grep -q -E "(docker-compose\.dev\.yml|docker-compose\.full\.yml|Dockerfile)"; then
         if ! run_full_validation; then
             exit_code=1
         fi


### PR DESCRIPTION
## Summary
- reuse cached list of staged files across infrastructure checks
- simplify full validation trigger to use staged file list directly

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6894617489548322a65837d05f4b0363