### PR TITLE
feat: externalize JWT secret

### DIFF
--- a/backend-user/backend-user-service/src/main/resources/application.yml
+++ b/backend-user/backend-user-service/src/main/resources/application.yml
@@ -24,13 +24,13 @@ spring:
     topics:
       user-registration: user-registration
 jwt:
-  secret: 9oSu9ugYxpECIJvtQJ3Q0FPT9jEC5hK3X5Pf7MYgfjSUcum3W9
+  secret: ${JWT_SECRET}
   expiration-ms: 86400000 # 24 часа
 management:
   endpoints:
     web:
       exposure:
-        include: health,metrics,prometheus
+        include: health,info,metrics,prometheus
   metrics:
     tags:
       application: ${spring.application.name}

--- a/infra/docker/compose/.env.example
+++ b/infra/docker/compose/.env.example
@@ -31,6 +31,7 @@ POSTGRES_PASSWORD=postgres           # Default password for PostgreSQL (dev only
 GRAFANA_ADMIN_PASSWORD=grafana       # Default Grafana admin password
 ELASTIC_PASSWORD=elastic             # Default password for Elasticsearch
 KIBANA_PASSWORD=kibana               # Default password for Kibana user
+JWT_SECRET=dev-secret                # Default JWT signing key (dev only)
 
 # Spring datasource defaults for development
 SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/aquastream_db

--- a/infra/docker/compose/docker-compose.dev.yml
+++ b/infra/docker/compose/docker-compose.dev.yml
@@ -52,6 +52,7 @@ services:
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      JWT_SECRET: ${JWT_SECRET:-dev-secret}
     depends_on:
       - postgres
       - kafka


### PR DESCRIPTION
## Summary
- read JWT secret from the `JWT_SECRET` environment variable
- expose the Spring Boot info actuator endpoint
- pass `JWT_SECRET` through docker-compose and `.env.example`

## Testing
- `./gradlew :backend-user:backend-user-service:test`


------
https://chatgpt.com/codex/tasks/task_e_6894683b6248832281b080669258d4e1