### PR TITLE
Expose actuator info endpoints and test

### DIFF
--- a/backend-crew/backend-crew-service/src/main/resources/application.yml
+++ b/backend-crew/backend-crew-service/src/main/resources/application.yml
@@ -7,7 +7,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,metrics,prometheus
+        include: health,info,metrics,prometheus
   metrics:
     tags:
       application: ${spring.application.name}

--- a/backend-crew/backend-crew-service/src/test/java/org/aquastream/crew/ActuatorSmokeTest.java
+++ b/backend-crew/backend-crew-service/src/test/java/org/aquastream/crew/ActuatorSmokeTest.java
@@ -52,8 +52,9 @@ class ActuatorSmokeTest {
     @Test
     void actuatorInfo() throws Exception {
         HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/actuator/info")).build();
-        HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isNotBlank();
     }
 
     @Test

--- a/backend-event/backend-event-service/src/test/java/org/aquastream/event/ActuatorSmokeTest.java
+++ b/backend-event/backend-event-service/src/test/java/org/aquastream/event/ActuatorSmokeTest.java
@@ -52,8 +52,9 @@ class ActuatorSmokeTest {
     @Test
     void actuatorInfo() throws Exception {
         HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/actuator/info")).build();
-        HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isNotBlank();
     }
 
     @Test

--- a/backend-gateway/backend-gateway-service/src/test/java/org/aquastream/gateway/ActuatorSmokeTest.java
+++ b/backend-gateway/backend-gateway-service/src/test/java/org/aquastream/gateway/ActuatorSmokeTest.java
@@ -52,8 +52,9 @@ class ActuatorSmokeTest {
     @Test
     void actuatorInfo() throws Exception {
         HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/actuator/info")).build();
-        HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isNotBlank();
     }
 
     @Test

--- a/backend-notification/backend-notification-service/src/main/resources/application.yml
+++ b/backend-notification/backend-notification-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,metrics,prometheus
+        include: health,info,metrics,prometheus
   metrics:
     tags:
       application: ${spring.application.name}

--- a/backend-notification/backend-notification-service/src/test/java/org/aquastream/notification/ActuatorSmokeTest.java
+++ b/backend-notification/backend-notification-service/src/test/java/org/aquastream/notification/ActuatorSmokeTest.java
@@ -46,8 +46,9 @@ class ActuatorSmokeTest {
     @Test
     void actuatorInfo() throws Exception {
         HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/actuator/info")).build();
-        HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isNotBlank();
     }
 
     @Test

--- a/backend-user/backend-user-service/src/test/java/org/aquastream/user/ActuatorSmokeTest.java
+++ b/backend-user/backend-user-service/src/test/java/org/aquastream/user/ActuatorSmokeTest.java
@@ -46,8 +46,9 @@ class ActuatorSmokeTest {
     @Test
     void actuatorInfo() throws Exception {
         HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/actuator/info")).build();
-        HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isNotBlank();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- expose `info` actuator endpoint for crew and notification services
- assert `/actuator/info` returns non-empty response in smoke tests for all services

## Testing
- `./gradlew :backend-crew:backend-crew-service:test :backend-notification:backend-notification-service:test :backend-event:backend-event-service:test :backend-gateway:backend-gateway-service:test :backend-user:backend-user-service:test`


------
https://chatgpt.com/codex/tasks/task_e_68946c9a09c08322bbd66fb7f2b47a94