### PR TITLE
chore: remove frontend from gradle projects

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,6 @@ include 'backend-crew:backend-crew-db'
 include 'backend-crew:backend-crew-service'
 
 // Other modules
-include 'frontend'
 include 'common'
 include 'infra'
 


### PR DESCRIPTION
## Summary
- remove unused `frontend` module from settings.gradle

## Testing
- `./gradlew projects`


------
https://chatgpt.com/codex/tasks/task_e_6894710d92248322b572f717a1a72401