### PR TITLE
feat: add fast start option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ cp infra/docker/compose/.env.example infra/docker/compose/.env
 ./run.sh check -fe   # Запуск линтеров и тестов фронтенда
 ./run.sh dev -be    # Запуск бэкенда с горячей перезагрузкой
 ./run.sh dev -fe    # Запуск фронтенда в режиме разработки
-./run.sh start       # Поднимает Docker-инфраструктуру
+./run.sh start              # Поднимает Docker-инфраструктуру с пересборкой контейнеров
+./run.sh start --no-build   # Быстрый запуск без пересборки контейнеров
 ./run.sh restart     # Перезапускает Docker-инфраструктуру
 ./run.sh status      # Показывает статус контейнеров
 ./run.sh logs        # Показывает логи контейнеров

--- a/run.sh
+++ b/run.sh
@@ -130,7 +130,11 @@ case "$1" in
       cp "$ENV_EXAMPLE" "$ENV_FILE"
       echo "Created $ENV_FILE from example."
     fi
-    run_cmd docker compose -f "$COMPOSE_FILE" up -d
+    if [ "$2" = "--no-build" ]; then
+      run_cmd docker compose -f "$COMPOSE_FILE" up -d
+    else
+      run_cmd docker compose -f "$COMPOSE_FILE" up -d --build
+    fi
     ;;
   stop)
     run_cmd docker compose -f "$COMPOSE_FILE" down -v
@@ -146,7 +150,7 @@ case "$1" in
     run_cmd docker compose -f "$COMPOSE_FILE" logs -f
     ;;
   *)
-    echo "Usage: $0 {build|test|lint|check|dev|start|stop|restart|status|logs} [-be|-fe|-docker]"
+    echo "Usage: $0 {build|test|lint|check|dev|start|stop|restart|status|logs} [-be|-fe|-docker|--no-build]"
     exit 1
     ;;
 


### PR DESCRIPTION
## Summary
- build docker images by default when starting compose
- support `start --no-build` to skip rebuilding containers
- document fast and full start options

## Testing
- `shellcheck run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68947d2dfcd083229a53635034045ac0