### PR TITLE
Exclude datasource auto configuration in tests

### DIFF
--- a/backend-crew/backend-crew-service/src/test/resources/application.yml
+++ b/backend-crew/backend-crew-service/src/test/resources/application.yml
@@ -1,3 +1,7 @@
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
 server:
   port: 0
 management:

--- a/backend-event/backend-event-service/src/test/resources/application.yml
+++ b/backend-event/backend-event-service/src/test/resources/application.yml
@@ -1,3 +1,7 @@
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
 server:
   port: 0
 management:

--- a/backend-gateway/backend-gateway-service/src/test/resources/application.yml
+++ b/backend-gateway/backend-gateway-service/src/test/resources/application.yml
@@ -1,3 +1,7 @@
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
 server:
   port: 0
 management:

--- a/backend-notification/backend-notification-service/src/test/resources/application.yml
+++ b/backend-notification/backend-notification-service/src/test/resources/application.yml
@@ -1,3 +1,7 @@
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
 server:
   port: 0
 management:

--- a/backend-user/backend-user-service/src/test/resources/application.yml
+++ b/backend-user/backend-user-service/src/test/resources/application.yml
@@ -1,3 +1,7 @@
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
 server:
   port: 0
 management:


### PR DESCRIPTION
## Summary
- avoid datasource auto-configuration during tests by excluding `DataSourceAutoConfiguration` in each service's test `application.yml`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68947d0a7da48322a8b7d5e7eec7208d