### PR TITLE
Restrict actuator endpoints to health and info

### DIFF
--- a/backend-crew/backend-crew-service/src/main/resources/application.yml
+++ b/backend-crew/backend-crew-service/src/main/resources/application.yml
@@ -7,10 +7,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
-  metrics:
-    tags:
-      application: ${spring.application.name}
+        include: health,info
 aquastream:
   logging:
     structured:

--- a/backend-event/backend-event-service/src/main/resources/application.yml
+++ b/backend-event/backend-event-service/src/main/resources/application.yml
@@ -32,33 +32,12 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
+        include: health,info
       base-path: /actuator
   endpoint:
     health:
       show-details: when_authorized
       show-components: always
-    prometheus:
-      enabled: true
-    metrics:
-      enabled: true
-  metrics:
-    tags:
-      application: ${spring.application.name}
-      service: event-service
-      version: 1.0.0
-    export:
-      prometheus:
-        enabled: true
-        step: 10s
-        descriptions: true
-    distribution:
-      percentiles-histogram:
-        grpc.server.duration.seconds: true
-        http.server.requests: true
-      slo:
-        grpc.server.duration.seconds: 50ms,100ms,200ms,500ms,1s,2s,5s
-        http.server.requests: 50ms,100ms,200ms,500ms,1s,2s,5s
 logging:
   level:
     org.aquastream.event: DEBUG

--- a/backend-gateway/backend-gateway-service/src/main/resources/application.yml
+++ b/backend-gateway/backend-gateway-service/src/main/resources/application.yml
@@ -62,7 +62,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,gateway
+        include: health,info
 springdoc:
   api-docs:
     path: /api/docs

--- a/backend-notification/backend-notification-service/src/main/resources/application.yml
+++ b/backend-notification/backend-notification-service/src/main/resources/application.yml
@@ -10,10 +10,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
-  metrics:
-    tags:
-      application: ${spring.application.name}
+        include: health,info
 ---
 spring:
   config:

--- a/backend-user/backend-user-service/src/main/resources/application.yml
+++ b/backend-user/backend-user-service/src/main/resources/application.yml
@@ -30,10 +30,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
-  metrics:
-    tags:
-      application: ${spring.application.name}
+        include: health,info
 springdoc:
   api-docs:
     path: /api-docs


### PR DESCRIPTION
## Summary
- limit actuator exposure to health and info across backend services
- drop metrics/prometheus and gateway endpoint configurations

## Testing
- `./gradlew test`
- `run.sh build -docker` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `curl -s localhost:8082/actuator/health`
- `curl -s localhost:8082/actuator/info`


------
https://chatgpt.com/codex/tasks/task_e_6894893a4c348322871bf30758a448f8