### PR TITLE
Optimize Docker build context and cache Gradle dependencies

### DIFF
--- a/infra/docker/images/Dockerfile.backend
+++ b/infra/docker/images/Dockerfile.backend
@@ -7,11 +7,12 @@ ARG SERVICE
 FROM eclipse-temurin:${ECLIPSE_TEMURIN_JDK_TAG} AS build
 WORKDIR /workspace
 
-# Copy entire repository
-COPY . /workspace
+# Copy only necessary files and directories
+COPY build.gradle settings.gradle gradle/ gradlew* common/ ${SERVICE} /workspace/
 
 # Build jar for selected service
-RUN ./gradlew :${SERVICE//\//:}:bootJar --no-daemon --build-cache \
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :${SERVICE//\//:}:bootJar --no-daemon --build-cache \
     && cp "$(find "${SERVICE}/build/libs" -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n1)" app.jar
 
 # --- Stage 2: runtime -----------------------------


### PR DESCRIPTION
## Summary
- Copy only Gradle and service-specific files into the builder image for leaner context
- Cache Gradle dependencies during build stage with `--mount=type=cache`

## Testing
- `DOCKER_BUILDKIT=1 docker build -f infra/docker/images/Dockerfile.backend --build-arg SERVICE=backend-user/backend-user-service .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68949e3c25648322b748949a890236c9