### PR TITLE
refactor: centralize service env vars

### DIFF
--- a/infra/docker/compose/.env
+++ b/infra/docker/compose/.env
@@ -1,0 +1,5 @@
+SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/aquastream_db
+SPRING_DATASOURCE_USERNAME=postgres
+SPRING_DATASOURCE_PASSWORD=postgres
+KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+JWT_SECRET=dev-secret

--- a/infra/docker/compose/docker-compose.dev.yml
+++ b/infra/docker/compose/docker-compose.dev.yml
@@ -47,12 +47,7 @@ services:
       dockerfile: infra/docker/images/Dockerfile.backend
       args:
         SERVICE: backend-user/backend-user-service
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/aquastream_db
-      SPRING_DATASOURCE_USERNAME: postgres
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      JWT_SECRET: ${JWT_SECRET:-dev-secret}
+    env_file: .env
     depends_on:
       - postgres
       - kafka
@@ -67,11 +62,7 @@ services:
       dockerfile: infra/docker/images/Dockerfile.backend
       args:
         SERVICE: backend-event/backend-event-service
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/aquastream_db
-      SPRING_DATASOURCE_USERNAME: postgres
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    env_file: .env
     depends_on:
       - postgres
       - kafka
@@ -87,11 +78,7 @@ services:
       dockerfile: infra/docker/images/Dockerfile.backend
       args:
         SERVICE: backend-crew/backend-crew-service
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/aquastream_db
-      SPRING_DATASOURCE_USERNAME: postgres
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    env_file: .env
     depends_on:
       - postgres
       - kafka
@@ -106,11 +93,7 @@ services:
       dockerfile: infra/docker/images/Dockerfile.backend
       args:
         SERVICE: backend-notification/backend-notification-service
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/aquastream_db
-      SPRING_DATASOURCE_USERNAME: postgres
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    env_file: .env
     depends_on:
       - postgres
       - kafka


### PR DESCRIPTION
## Summary
- add shared `.env` with database, Kafka and JWT variables
- load env file in backend services and remove duplicate environment settings

## Testing
- `docker compose -f infra/docker/compose/docker-compose.dev.yml up -d` *(fails: unknown shorthand flag: 'f')*
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68949e9cb4048322844177a01f823279