### PR TITLE
chore: remove unused database configs

### DIFF
--- a/backend-crew/backend-crew-service/build.gradle
+++ b/backend-crew/backend-crew-service/build.gradle
@@ -15,14 +15,11 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation "org.springframework.kafka:spring-kafka:${rootProject.springKafkaVersion}"
     implementation project(':common')
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    
-    runtimeOnly 'org.postgresql:postgresql'
-    
+
     implementation "io.grpc:grpc-netty-shaded:${rootProject.grpcVersion}"
     implementation "io.grpc:grpc-protobuf:${rootProject.grpcVersion}"
     implementation "io.grpc:grpc-stub:${rootProject.grpcVersion}"

--- a/backend-crew/backend-crew-service/src/main/resources/application.yml
+++ b/backend-crew/backend-crew-service/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 spring:
-  config:
-    import: classpath:db-common.yml
   application:
     name: crew-service
 management:

--- a/backend-event/backend-event-service/src/main/resources/application.yml
+++ b/backend-event/backend-event-service/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 spring:
-  config:
-    import: classpath:db-common.yml
   application:
     name: event-service
   kafka:

--- a/backend-gateway/backend-gateway-service/build.gradle
+++ b/backend-gateway/backend-gateway-service/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 dependencies {
     implementation project(':backend-gateway:backend-gateway-api')
-    implementation project(':backend-gateway:backend-gateway-db')
     implementation project(':common')
     
     // Gateway работает с WebFlux, не с Web MVC

--- a/backend-gateway/backend-gateway-service/src/main/resources/application.yml
+++ b/backend-gateway/backend-gateway-service/src/main/resources/application.yml
@@ -1,17 +1,6 @@
 spring:
-  config:
-    import: classpath:db-common.yml
   application:
     name: gateway-service
-  jpa:
-    hibernate:
-      ddl-auto: none
-    show-sql: false
-    properties:
-      hibernate:
-        format_sql: true
-  liquibase:
-    change-log: classpath:db/changelog/db.changelog-master.yaml
   cloud:
     gateway:
       globalcors:

--- a/backend-notification/backend-notification-service/build.gradle
+++ b/backend-notification/backend-notification-service/build.gradle
@@ -12,11 +12,9 @@ repositories {
 
 dependencies {
     implementation project(':backend-notification:backend-notification-api')
-    implementation project(':backend-notification:backend-notification-db')
     implementation project(':common')
-    
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation "org.springframework.kafka:spring-kafka:${rootProject.springKafkaVersion}"

--- a/backend-notification/backend-notification-service/src/main/resources/application.yml
+++ b/backend-notification/backend-notification-service/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 spring:
-  config:
-    import: classpath:db-common.yml
   application:
     name: notification-service
   kafka:


### PR DESCRIPTION
## Summary
- drop JPA and Liquibase config from gateway
- strip unused DB imports from crew, event and notification services
- remove database dependencies from gateway, crew and notification builds

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68949ee36dc88322849ca9afb7052d5a