### PR TITLE
refactor: use cn instead of clsx in UI components

### DIFF
--- a/frontend/src/components/ui/Card/Card.tsx
+++ b/frontend/src/components/ui/Card/Card.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@utils/cn';
 import React, { ReactNode } from 'react';
 
 export interface CardProps {
@@ -130,7 +130,7 @@ export const Card: React.FC<CardProps> = ({
   const isInteractive = !!onClick;
 
   // Составляем финальные классы
-  const cardClasses = clsx(
+  const cardClasses = cn(
     baseClasses,
     variantClasses[variant],
     finalHoverEffect !== 'none' && hoverEffectClasses[finalHoverEffect],
@@ -164,7 +164,7 @@ export const Card: React.FC<CardProps> = ({
  * Компонент CardHeader - заголовок карточки
  */
 export const CardHeader: React.FC<CardHeaderProps> = ({ children, className = '' }) => {
-  const classes = clsx('flex items-center mb-4', className);
+  const classes = cn('flex items-center mb-4', className);
   return <div className={classes} data-testid="card-header">{children}</div>;
 };
 
@@ -172,7 +172,7 @@ export const CardHeader: React.FC<CardHeaderProps> = ({ children, className = ''
  * Компонент CardTitle - название карточки
  */
 export const CardTitle: React.FC<CardTitleProps> = ({ children, className = '' }) => {
-  const classes = clsx('text-lg font-semibold text-secondary-950 dark:text-secondary-50', className);
+  const classes = cn('text-lg font-semibold text-secondary-950 dark:text-secondary-50', className);
   return <div className={classes} data-testid="card-title">{children}</div>;
 };
 
@@ -180,7 +180,7 @@ export const CardTitle: React.FC<CardTitleProps> = ({ children, className = '' }
  * Компонент CardContent - тело карточки
  */
 export const CardContent: React.FC<CardContentProps> = ({ children, className = '' }) => {
-  const classes = clsx('', className);
+  const classes = cn('', className);
   return <div className={classes} data-testid="card-content">{children}</div>;
 };
 
@@ -188,7 +188,7 @@ export const CardContent: React.FC<CardContentProps> = ({ children, className = 
  * Компонент CardFooter - футер карточки
  */
 export const CardFooter: React.FC<CardFooterProps> = ({ children, className = '' }) => {
-  const classes = clsx(
+  const classes = cn(
     'flex items-center justify-end mt-4 pt-4 border-t border-secondary-200 dark:border-secondary-700',
     className
   );

--- a/frontend/src/components/ui/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/ui/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@utils/cn';
 import React, { useId } from 'react';
 
 import { Typography } from '../Typography';
@@ -80,7 +80,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   };
 
   // Составляем классы для чекбокса
-  const checkboxClasses = clsx(
+  const checkboxClasses = cn(
     'appearance-none',
     'rounded',
     'border',
@@ -101,13 +101,13 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   );
 
   // Классы для контейнера чекбокса и метки
-  const containerClasses = clsx('flex items-center', {
+  const containerClasses = cn('flex items-center', {
     'cursor-pointer': !disabled,
     'cursor-not-allowed opacity-60': disabled,
   });
 
   // Классы для видимого индикатора чекбокса (галочка)
-  const indicatorClasses = clsx('absolute inset-0 flex items-center justify-center', {
+  const indicatorClasses = cn('absolute inset-0 flex items-center justify-center', {
     'text-primary-100': checked && !disabled,
     'text-secondary-400 dark:text-secondary-500': checked && disabled,
   });

--- a/frontend/src/components/ui/Input/Input.tsx
+++ b/frontend/src/components/ui/Input/Input.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@utils/cn';
 import { forwardRef, InputHTMLAttributes, ReactNode, useCallback, useId } from 'react';
 
 export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
@@ -92,7 +92,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       }
     }, [onChange, onClear]);
 
-    const wrapperClasses = clsx('flex flex-col', fullWidth ? 'w-full' : '', wrapperClassName);
+    const wrapperClasses = cn('flex flex-col', fullWidth ? 'w-full' : '', wrapperClassName);
 
     const baseInputClasses =
       'bg-secondary-50 dark:bg-secondary-900 border rounded-md focus:outline-none transition-colors';
@@ -118,7 +118,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       right: (rightIcon || showClearButton) ? 'pr-9' : '',
     };
 
-    const inputClasses = clsx(
+    const inputClasses = cn(
       baseInputClasses,
       sizeClasses[size],
       error ? stateClasses.error : stateClasses.normal,

--- a/frontend/src/components/ui/LazyImage/LazyImage.tsx
+++ b/frontend/src/components/ui/LazyImage/LazyImage.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@utils/cn';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 
 import { LazyImageProps, ObjectFitMode, FadeInAnimation, RoundedSize, ShadowSize, HoverEffect } from './types';
@@ -151,7 +151,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   };
 
   // Определяем классы для контейнера
-  const containerClasses = clsx(
+  const containerClasses = cn(
     'lazy-image-container relative inline-block overflow-hidden align-top',
     placeholderColor,
     roundedClasses[rounded],
@@ -166,7 +166,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   );
 
   // Определяем классы для изображения
-  const imageClasses = clsx(
+  const imageClasses = cn(
     'block w-full h-full',
     objectFitClasses[objectFit],
     fadeAnimationClasses[fadeAnimation],
@@ -175,13 +175,13 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   );
 
   // Классы для прелоадера
-  const preloaderClasses = clsx(
+  const preloaderClasses = cn(
     'absolute inset-0 flex items-center justify-center transition-opacity duration-300',
     isLoaded || isError ? 'opacity-0 pointer-events-none' : 'opacity-100'
   );
 
   // Классы для информации о состоянии ошибки
-  const errorClasses = clsx(
+  const errorClasses = cn(
     'absolute inset-0 flex flex-col items-center justify-center bg-secondary-100 dark:bg-secondary-800 transition-opacity duration-300',
     isError && !fallbackSrc ? 'opacity-100' : 'opacity-0 pointer-events-none'
   );

--- a/frontend/src/components/ui/Modal/Modal.tsx
+++ b/frontend/src/components/ui/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@utils/cn';
 import React, { ReactNode, useEffect, useRef } from 'react';
 
 export interface ModalProps {
@@ -94,7 +94,7 @@ export const Modal: React.FC<ModalProps> = ({
   };
 
   // Формируем классы для модального окна
-  const modalClasses = clsx(
+  const modalClasses = cn(
     'bg-secondary-50 dark:bg-secondary-900 rounded-lg shadow-xl',
     'overflow-hidden',
     'transition-all duration-300',

--- a/frontend/src/components/ui/TextField/TextField.tsx
+++ b/frontend/src/components/ui/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@utils/cn';
 import React, { forwardRef, useState, useId } from 'react';
 
 // Типы для размеров и вариантов текстового поля
@@ -96,16 +96,16 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
     // Стили для разных вариантов отображения
     const variantClasses = {
-      outlined: clsx(
+      outlined: cn(
         'bg-transparent border rounded-md',
         error ? 'border-error-300 dark:border-error-600' : 'border-secondary-300 dark:border-secondary-600'
       ),
       filled: 'border-0 bg-secondary-100 dark:bg-secondary-800 rounded-md',
-      underlined: clsx(
+      underlined: cn(
         'border-0 border-b bg-transparent rounded-none px-0',
         error ? 'border-error-300 dark:border-error-600' : 'border-secondary-300 dark:border-secondary-600'
       ),
-      floating: clsx(
+      floating: cn(
         'bg-transparent border rounded-md pt-5',
         error ? 'border-error-300 dark:border-error-600' : 'border-secondary-300 dark:border-secondary-600'
       ),
@@ -127,7 +127,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     };
 
     // Базовые стили для инпута
-    const inputClasses = clsx(
+    const inputClasses = cn(
       'w-full transition-colors duration-200 outline-none focus:ring-2 focus:ring-offset-0',
       'placeholder-secondary-400 dark:placeholder-secondary-500 text-secondary-950 dark:text-secondary-50',
       'disabled:opacity-50 disabled:cursor-not-allowed',
@@ -149,13 +149,13 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     );
 
     // Контейнер для компонента
-    const containerClasses = clsx(
+    const containerClasses = cn(
       fullWidth ? 'w-full' : 'inline-block',
       appearEffectClasses[appearEffect]
     );
 
     // Классы для лейбла
-    const labelClasses = clsx(
+    const labelClasses = cn(
       'block text-sm font-medium mb-1',
       isFocused ? {
           'text-primary-600 dark:text-primary-400': activeColor === 'primary',
@@ -170,11 +170,11 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     );
 
     // Классы для плавающего лейбла
-    const floatingLabelClasses = clsx(
+    const floatingLabelClasses = cn(
       'absolute text-sm transition-all duration-200',
       'left-2.5 bg-secondary-50 dark:bg-secondary-900 px-1 pointer-events-none',
       isFocused || hasValue
-        ? clsx(
+        ? cn(
             '-translate-y-3 scale-75 origin-left',
             {
                 'text-primary-600 dark:text-primary-400': activeColor === 'primary',
@@ -204,7 +204,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         <div className="relative">
           {startIcon && (
             <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-              <span className={clsx('text-secondary-500 dark:text-secondary-400', isFocused && {
+              <span className={cn('text-secondary-500 dark:text-secondary-400', isFocused && {
                   'text-primary-600 dark:text-primary-400': activeColor === 'primary',
                   'text-secondary-800 dark:text-secondary-400': activeColor === 'secondary',
                   'text-accent-600 dark:text-accent-400': activeColor === 'accent',
@@ -242,7 +242,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
           {endIcon && (
             <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
-              <span className={clsx('text-secondary-500 dark:text-secondary-400', isFocused && {
+              <span className={cn('text-secondary-500 dark:text-secondary-400', isFocused && {
                   'text-primary-600 dark:text-primary-400': activeColor === 'primary',
                   'text-secondary-800 dark:text-secondary-400': activeColor === 'secondary',
                   'text-accent-600 dark:text-accent-400': activeColor === 'accent',
@@ -260,7 +260,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         {displayHelperText && (
           <p
             id={`${elementId}-error`}
-            className={clsx(
+            className={cn(
               'text-xs mt-1',
               error ? 'text-error-600 dark:text-error-500' : 'text-secondary-600 dark:text-secondary-400'
             )}

--- a/frontend/src/components/ui/Typography/Typography.tsx
+++ b/frontend/src/components/ui/Typography/Typography.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@utils/cn';
 import React from 'react';
 
 // Типы для типографики
@@ -104,7 +104,7 @@ export const Typography: React.FC<TypographyProps> = ({
   };
 
   // Объединение всех классов
-  const classes = clsx(
+  const classes = cn(
     variantClasses[variant],
     colorClasses[color],
     alignClasses[align === 'inherit' ? 'inherit' : align],


### PR DESCRIPTION
## Summary
- use shared `cn` helper to combine classes in Input and other UI components
- remove direct `clsx` imports in favor of the `cn` utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894a5d1be5c8322a2facb69420e6b65