### PR TITLE
feat: simplify button size variants

### DIFF
--- a/frontend/src/components/EventCard/EventCard.tsx
+++ b/frontend/src/components/EventCard/EventCard.tsx
@@ -87,7 +87,7 @@ const EventCard: React.FC<EventCardProps> = React.memo(({
             <Link to={path} onClick={handleClick} className="w-full" data-testid="event-link-button">
               <Button
                 variant="primary"
-                size="medium"
+                size="md"
                 className="w-full rounded-md"
                 data-testid="event-button"
               >
@@ -97,7 +97,7 @@ const EventCard: React.FC<EventCardProps> = React.memo(({
           ) : (
             <Button
               variant="primary"
-              size="medium"
+              size="md"
               className="w-full rounded-md"
               onClick={handleClick}
               data-testid="event-action-button"

--- a/frontend/src/components/ui/Button/Button.stories.tsx
+++ b/frontend/src/components/ui/Button/Button.stories.tsx
@@ -93,21 +93,21 @@ export const Ghost: Story = {
 // Размеры кнопок
 export const Small: Story = {
   args: {
-    size: 'small',
+    size: 'sm',
     children: 'Маленькая кнопка',
   },
 };
 
 export const Medium: Story = {
   args: {
-    size: 'medium',
+    size: 'md',
     children: 'Средняя кнопка',
   },
 };
 
 export const Large: Story = {
   args: {
-    size: 'large',
+    size: 'lg',
     children: 'Большая кнопка',
   },
 };

--- a/frontend/src/components/ui/Button/Button.tsx
+++ b/frontend/src/components/ui/Button/Button.tsx
@@ -34,7 +34,7 @@ export const Button: React.FC<ButtonProps> = ({
   children,
   className,
   variant = 'primary',
-  size = 'medium',
+  size = 'md',
   fullWidth = false,
   disabled = false,
   loading = false,
@@ -61,30 +61,27 @@ export const Button: React.FC<ButtonProps> = ({
   };
 
   const sizeClasses: Record<ButtonSize, string> = {
-    small: 'text-sm px-3 py-1.5',
     sm: 'text-sm px-3 py-1.5',
-    medium: 'text-base px-4 py-2',
     md: 'text-base px-4 py-2',
-    large: 'text-lg px-6 py-3',
     lg: 'text-lg px-6 py-3',
   };
 
-  const spinnerSizeClasses: Record<'small' | 'medium' | 'large', string> = {
-    small: 'h-4 w-4',
-    medium: 'h-5 w-5',
-    large: 'h-6 w-6',
-  }
+  const spinnerSizeClasses: Record<ButtonSize, string> = {
+    sm: 'h-4 w-4',
+    md: 'h-5 w-5',
+    lg: 'h-6 w-6',
+  };
 
   const widthClass = fullWidth ? 'w-full' : '';
   const isDisabled = disabled || loading;
   const disabledClass = isDisabled ? 'opacity-50 cursor-not-allowed' : '';
 
-  const normalizedSize = size === 'sm' ? 'small' : size === 'md' ? 'medium' : size === 'lg' ? 'large' : size;
+  const normalizedSize = size;
 
   const buttonClasses = cn(
     baseClasses,
     variantClasses[variant === 'outlined' ? 'outline' : variant],
-    sizeClasses[size as ButtonSize],
+    sizeClasses[size],
     widthClass,
     disabledClass,
     className
@@ -99,7 +96,7 @@ export const Button: React.FC<ButtonProps> = ({
       data-testid={`button-${variant}`}
       {...props}
     >
-      {loading && <Spinner sizeClass={spinnerSizeClasses[normalizedSize as 'small'|'medium'|'large']} />}
+      {loading && <Spinner sizeClass={spinnerSizeClasses[normalizedSize]} />}
       {children}
     </button>
   );

--- a/frontend/src/components/ui/Button/Button.types.ts
+++ b/frontend/src/components/ui/Button/Button.types.ts
@@ -9,13 +9,7 @@ export type ButtonVariant =
   | 'accent'
   | 'ghost';
 
-export type ButtonSize =
-  | 'small'
-  | 'medium'
-  | 'large'
-  | 'sm' // alias
-  | 'md'
-  | 'lg';
+export type ButtonSize = 'sm' | 'md' | 'lg';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**

--- a/frontend/src/components/ui/Card/Card.stories.tsx
+++ b/frontend/src/components/ui/Card/Card.stories.tsx
@@ -67,7 +67,7 @@ export const Default: Story = {
     children: renderCardContent(
       'Стандартная карточка',
       <Typography>Это содержимое стандартной карточки.</Typography>,
-      <Button variant="primary" size="small">Действие</Button>
+      <Button variant="primary" size="sm">Действие</Button>
     ),
   },
 };
@@ -108,7 +108,7 @@ export const Primary: Story = {
     children: renderCardContent(
       'Основная карточка',
       <Typography>Карточка основного цвета.</Typography>,
-      <Button variant="ghost" size="small" className="text-white hover:bg-white/20 dark:hover:bg-white/20">Действие</Button>
+      <Button variant="ghost" size="sm" className="text-white hover:bg-white/20 dark:hover:bg-white/20">Действие</Button>
     ),
   },
 };

--- a/frontend/src/pages/UIKitPage/UIKitPage.tsx
+++ b/frontend/src/pages/UIKitPage/UIKitPage.tsx
@@ -40,27 +40,27 @@ const ButtonSection = () => {
         <div className="space-y-2">
           <Typography variant="subtitle-1">Primary</Typography>
           <div className="flex flex-wrap gap-2">
-            <Button variant="primary" size="small">Маленькая</Button>
+            <Button variant="primary" size="sm">Маленькая</Button>
             <Button variant="primary">Средняя</Button>
-            <Button variant="primary" size="large">Большая</Button>
+            <Button variant="primary" size="lg">Большая</Button>
           </div>
         </div>
         
         <div className="space-y-2">
           <Typography variant="subtitle-1">Secondary</Typography>
           <div className="flex flex-wrap gap-2">
-            <Button variant="secondary" size="small">Маленькая</Button>
+            <Button variant="secondary" size="sm">Маленькая</Button>
             <Button variant="secondary">Средняя</Button>
-            <Button variant="secondary" size="large">Большая</Button>
+            <Button variant="secondary" size="lg">Большая</Button>
           </div>
         </div>
         
         <div className="space-y-2">
           <Typography variant="subtitle-1">Outline</Typography>
           <div className="flex flex-wrap gap-2">
-            <Button variant="outline" size="small">Маленькая</Button>
+            <Button variant="outline" size="sm">Маленькая</Button>
             <Button variant="outline">Средняя</Button>
-            <Button variant="outline" size="large">Большая</Button>
+            <Button variant="outline" size="lg">Большая</Button>
           </div>
         </div>
       </div>
@@ -157,7 +157,7 @@ const CardSection = () => {
             </Typography>
           </CardContent>
           <CardFooter>
-            <Button variant="primary" size="small">Действие</Button>
+            <Button variant="primary" size="sm">Действие</Button>
           </CardFooter>
         </Card>
         
@@ -175,7 +175,7 @@ const CardSection = () => {
             </Typography>
           </CardContent>
           <CardFooter>
-            <Button variant="outline" size="small">Действие</Button>
+            <Button variant="outline" size="sm">Действие</Button>
           </CardFooter>
         </Card>
         
@@ -193,7 +193,7 @@ const CardSection = () => {
             </Typography>
           </CardContent>
           <CardFooter>
-            <Button variant="secondary" size="small">Действие</Button>
+            <Button variant="secondary" size="sm">Действие</Button>
           </CardFooter>
         </Card>
         
@@ -211,7 +211,7 @@ const CardSection = () => {
             </Typography>
           </CardContent>
           <CardFooter>
-            <Button variant="outline" size="small">Действие</Button>
+            <Button variant="outline" size="sm">Действие</Button>
           </CardFooter>
         </Card>
         
@@ -229,7 +229,7 @@ const CardSection = () => {
             </Typography>
           </CardContent>
           <CardFooter>
-            <Button variant="primary" size="small">Действие</Button>
+            <Button variant="primary" size="sm">Действие</Button>
           </CardFooter>
         </Card>
         

--- a/infra/docs/system-analysis/frontend/src/components/ui/README.md
+++ b/infra/docs/system-analysis/frontend/src/components/ui/README.md
@@ -43,7 +43,7 @@ Storybook будет доступен по адресу http://localhost:6006
 Кнопка с различными вариантами стилей, размеров и возможностью добавления иконок.
 
 ```tsx
-<Button variant="primary" size="medium" onClick={handleClick}>
+<Button variant="primary" size="md" onClick={handleClick}>
   Нажми меня
 </Button>
 ```

--- a/infra/docs/system-analysis/frontend/storybook-guidelines.md
+++ b/infra/docs/system-analysis/frontend/storybook-guidelines.md
@@ -124,7 +124,7 @@ export const Secondary: Story = {
 // Размеры
 export const Small: Story = {
   args: {
-    size: 'small',
+    size: 'sm',
     children: 'Маленькая кнопка',
   },
 };


### PR DESCRIPTION
## Summary
- streamline Button to accept only `sm`, `md`, and `lg` sizes and simplify normalizedSize handling
- update examples, stories, and documentation to the new size tokens
- adjust components using Button to new size names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894a5be3f308322a7140916eabc5966