### PR TITLE
refactor: switch theme tokens to css variables

### DIFF
--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -7,7 +7,6 @@ import Logo from './Logo';
 import NavigationMenu from './NavigationMenu';
 import { NavItem, HeaderProps } from './types';
 
-import { lightTheme, darkTheme } from '@/theme';
 
 /**
  * Компонент Header - шапка сайта с навигацией и логотипом
@@ -80,9 +79,7 @@ const Header: React.FC<HeaderProps> = ({
         opacityDuration: 0.15,
       }}
     >
-      <div className={`flex items-center justify-between w-auto max-w-screen-xl mx-auto rounded-[15px] shadow-md px-5 py-3 transition-colors ${
-        theme === 'dark' ? darkTheme.header : lightTheme.header
-      }`}>
+      <div className="flex items-center justify-between w-auto max-w-screen-xl mx-auto rounded-[15px] shadow-md px-5 py-3 transition-colors bg-[#1E2841] rounded-xl">
         {/* Логотип */}
         <div className="flex-shrink-0 mr-6">
           <Logo onClick={closeMenu} />

--- a/frontend/src/components/layout/Header/NavigationItem.tsx
+++ b/frontend/src/components/layout/Header/NavigationItem.tsx
@@ -3,8 +3,6 @@ import { NavLink } from 'react-router-dom';
 
 import { NavItem } from './types';
 
-import { lightTheme, darkTheme } from '@/theme';
-
 /**
  * Свойства компонента навигационного пункта
  */
@@ -17,10 +15,6 @@ interface NavigationItemProps {
    * Режим отображения
    */
   mode?: 'text' | 'icon' | 'both';
-  /**
-   * Текущая тема
-   */
-  theme: 'light' | 'dark';
   /**
    * Отображаемое имя пункта
    */
@@ -42,10 +36,9 @@ interface NavigationItemProps {
 /**
  * Компонент для отображения навигационного пункта меню
  */
-const NavigationItem: React.FC<NavigationItemProps> = React.memo(({
+const NavigationItem: React.FC<NavigationItemProps> = React.memo(({ 
   item,
   mode = 'text',
-  theme,
   displayName,
   renderIcon,
   className,
@@ -71,18 +64,14 @@ const NavigationItem: React.FC<NavigationItemProps> = React.memo(({
 
   // CSS классы для пункта меню в зависимости от текущей темы и активности
   const getLinkClasses = ({ isActive }: { isActive: boolean }) => `
-    ${mode === 'icon' ? 'p-2' : 'px-3 py-2'} 
-    rounded-md 
-    ${mode === 'text' ? 'text-sm font-medium' : ''} 
+    ${mode === 'icon' ? 'p-2' : 'px-3 py-2'}
+    rounded-md
+    ${mode === 'text' ? 'text-sm font-medium' : ''}
     transition-colors
     ${
-      theme === 'dark'
-        ? isActive
-          ? darkTheme.activeNavItem
-          : darkTheme.navItem
-        : isActive
-          ? lightTheme.activeNavItem
-          : lightTheme.navItem
+      isActive
+        ? 'text-primary bg-secondary/30 font-medium'
+        : 'text-gray-300 hover:text-primary hover:bg-secondary/60'
     }
     ${className || ''}
   `;

--- a/frontend/src/components/layout/Header/NavigationMenu.tsx
+++ b/frontend/src/components/layout/Header/NavigationMenu.tsx
@@ -94,7 +94,6 @@ const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(({
           key={item.id || item.path}
           item={item}
           mode={mode}
-          theme={theme}
           displayName={getItemDisplayName(item)}
           renderIcon={renderIcon}
           onClick={handleNavigationClick}
@@ -105,7 +104,6 @@ const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(({
       <NavigationItem
         item={profileItem}
         mode={mode}
-        theme={theme}
         displayName={getItemDisplayName(profileItem)}
         renderIcon={mode === 'text' ? undefined : () => <UserCircle className="w-5 h-5" />}
         onClick={handleNavigationClick}

--- a/frontend/src/components/layout/Header/ThemeSwitcher.tsx
+++ b/frontend/src/components/layout/Header/ThemeSwitcher.tsx
@@ -1,7 +1,6 @@
 import { Sun, Moon } from 'lucide-react';
 import React from 'react';
 
-import { lightTheme, darkTheme } from '@/theme';
 
 /**
  * Свойства компонента переключателя темы
@@ -35,9 +34,7 @@ const ThemeSwitcher: React.FC<ThemeSwitcherProps> = React.memo(({
     <button
       type="button"
       aria-label="Переключить тему"
-      className={`p-2 rounded-full transition-colors ${
-        theme === 'dark' ? darkTheme.themeToggle : lightTheme.themeToggle
-      } ${className || ''}`}
+      className={`p-2 rounded-full transition-colors text-gray-300 hover:text-primary hover:bg-secondary/60 ${className || ''}`}
       onClick={onToggle}
       title={themeTitle}
       data-testid="theme-switcher"

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -9,7 +9,6 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import Header from '../Header/Header';
 
 import { renderWithProviders } from '@/test/utils';
-import { lightTheme, darkTheme } from '@/theme';
 
 // Создаем mockTranslate перед использованием
 const mockTranslate = vi.fn((key) => {
@@ -55,17 +54,16 @@ describe('Header Component', () => {
     expect(themeToggleButton).toBeInTheDocument();
   });
 
-  it('applies correct theme classes based on theme prop', () => {
-    // Сначала проверяем темную тему
+  it('renders correct theme icon based on theme prop', () => {
+    // Проверяем темную тему
     const { unmount } = renderWithProviders(
       <MemoryRouter>
         <Header navItems={mockNavItems} theme="dark" />
       </MemoryRouter>
     );
 
-    // Проверяем, что шапка имеет правильные классы для темной темы
-    const darkHeaderInner = screen.getByTestId('header-scroll').querySelector('div');
-    expect(darkHeaderInner).toHaveClass(darkTheme.header);
+    const lightIcon = screen.getAllByTestId('light-icon')[0];
+    expect(lightIcon).toBeInTheDocument();
 
     // Размонтируем компонент и очищаем DOM
     unmount();
@@ -78,8 +76,8 @@ describe('Header Component', () => {
       </MemoryRouter>
     );
 
-    const lightHeaderInner = screen.getByTestId('header-scroll').querySelector('div');
-    expect(lightHeaderInner).toHaveClass(lightTheme.header);
+    const darkIcon = screen.getAllByTestId('dark-icon')[0];
+    expect(darkIcon).toBeInTheDocument();
   });
 
   it('calls onThemeToggle when theme button is clicked', async () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,6 +16,10 @@
     /* Добавляем переменные для цветов из tailwind.config.js для border и muted */
     --border: 216, 220, 229; /* secondary.200 */
     --muted: 114, 129, 157; /* secondary.500 */
+    /* Основные цветовые токены */
+    --primary: 234, 79, 59; /* primary.500 */
+    --secondary: 54, 62, 83; /* secondary.800 */
+    --accent: 218, 188, 118; /* accent.400 */
   }
 
   .dark {
@@ -28,6 +32,9 @@
     /* Переменные для темной темы */
     --border: 77, 88, 114; /* secondary.700 */
     --muted: 144, 156, 181; /* secondary.400 */
+    --primary: 247, 121, 108; /* primary.400 */
+    --secondary: 54, 62, 83; /* secondary.800 */
+    --accent: 218, 188, 118; /* accent.400 */
   }
 
   body {

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -56,29 +56,3 @@ export const createTheme = (options: ThemeOptions = {}): AppTheme => {
     borderRadius: options.borderRadius || '0.375rem', // rounded-md
   };
 };
-
-/**
- * Классы для светлой темы компонентов UI
- */
-export const lightTheme = {
-  header: 'bg-[#1E2841] rounded-xl',
-  logo: 'text-primary-500',
-  navItem: 'text-gray-300 hover:text-primary-400 hover:bg-secondary-800/60 rounded-md',
-  activeNavItem: 'text-primary-400 bg-secondary-800/30 font-medium rounded-md',
-  themeToggle: 'text-gray-300 hover:text-primary-400 hover:bg-secondary-800/60',
-  mobileMenuButton: 'text-gray-300 hover:text-primary-400 hover:bg-secondary-800/60',
-  mobileMenu: 'bg-[#1E2841] border-t border-secondary-800',
-};
-
-/**
- * Классы для темной темы компонентов UI
- */
-export const darkTheme = {
-  header: 'bg-[#1E2841] rounded-xl',
-  logo: 'text-primary-400',
-  navItem: 'text-gray-300 hover:text-primary-400 hover:bg-secondary-800/60 rounded-md',
-  activeNavItem: 'text-primary-400 bg-secondary-800/30 font-medium rounded-md',
-  themeToggle: 'text-gray-300 hover:text-primary-400 hover:bg-secondary-800/60',
-  mobileMenuButton: 'text-gray-300 hover:text-primary-400 hover:bg-secondary-800/60',
-  mobileMenu: 'bg-[#1E2841] border-t border-secondary-800',
-};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -9,6 +9,7 @@ export default {
     extend: {
       colors: {
         primary: {
+          DEFAULT: 'rgb(var(--primary) / <alpha-value>)',
           50: '#fef3f2',
           100: '#fde7e4',
           200: '#fdd2cc',
@@ -22,6 +23,7 @@ export default {
           950: '#42110c',
         },
         secondary: {
+          DEFAULT: 'rgb(var(--secondary) / <alpha-value>)',
           50: '#f5f7fa',
           100: '#ebeef3',
           200: '#d8dce5',
@@ -35,6 +37,7 @@ export default {
           950: '#1f2332',
         },
         accent: {
+          DEFAULT: 'rgb(var(--accent) / <alpha-value>)',
           50: '#fbf9f1',
           100: '#f6f1de',
           200: '#eee4bd',
@@ -99,8 +102,8 @@ export default {
           900: '#1e3a8a',
           950: '#172554',
         },
-        border: 'rgb(var(--border))',
-        muted: 'rgb(var(--muted))',
+        border: 'rgb(var(--border) / <alpha-value>)',
+        muted: 'rgb(var(--muted) / <alpha-value>)',
       },
       borderRadius: {
         'DEFAULT': '0.5rem',


### PR DESCRIPTION
## Summary
- define primary, secondary and accent colors as CSS variables in Tailwind and global styles
- remove light/dark theme class maps and use tokens in header components
- update tests for new theme icon logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894af0db2a88322ba7b335d513a815c