### PR TITLE
chore: set ZooKeeper server id

### DIFF
--- a/infra/docker/compose/docker-compose.dev.yml
+++ b/infra/docker/compose/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
     image: bitnami/zookeeper:${ZOOKEEPER_TAG:-3.8}
     environment:
       ALLOW_ANONYMOUS_LOGIN: "yes"
+      ZOO_SERVER_ID: "1"
     ports:
       - "2181:2181"
     volumes:


### PR DESCRIPTION
## Summary
- configure ZooKeeper server ID in dev Docker Compose

## Testing
- `docker volume rm aquastream_zookeeper_data` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `./run.sh start` *(fails: docker: 'compose' is not a docker command. See 'docker --help')*


------
https://chatgpt.com/codex/tasks/task_e_6894b1e0297c8322b9b418d48cd22745