### PR TITLE
feat(theme): add cleanup for media query

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Layout from '@/components/layout/Layout';
 import { PageLoader } from '@/components/ui';
 import { useAppSelector } from '@/hooks/redux';
 import { selectUserState } from '@/store/slices/userSlice';
+import { initializeTheme } from '@/theme';
 
 const App = () => {
   const [darkMode, setDarkMode] = useState(false);
@@ -17,6 +18,14 @@ const App = () => {
     if (savedTheme === 'dark') {
       setDarkMode(true);
     }
+  }, []);
+
+  // Инициализация темы и удаление обработчиков при размонтировании
+  useEffect(() => {
+    const cleanup = initializeTheme();
+    return () => {
+      cleanup && cleanup();
+    };
   }, []);
 
   const toggleTheme = () => {

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -47,7 +47,7 @@ export const applyTheme = (theme: Theme): void => {
 /**
  * Инициализация темы при загрузке приложения
  */
-export const initializeTheme = (): void => {
+export const initializeTheme = (): (() => void) | void => {
   const storedTheme = getStoredTheme();
   applyTheme(storedTheme);
 
@@ -60,6 +60,11 @@ export const initializeTheme = (): void => {
     };
 
     mediaQuery.addEventListener('change', handleChange);
+
+    // Возвращаем функцию очистки, которая удаляет обработчик
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
   }
 };
 


### PR DESCRIPTION
## Summary
- add cleanup in `initializeTheme` to remove media query change listener
- invoke theme initialization in `App` and clean it up on unmount

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894b2a360308322a03c5e8f9e284fb5