### PR TITLE
Refactor auth slice to use OpenAPI models

### DIFF
--- a/frontend/src/api/adapters/authAdapter.ts
+++ b/frontend/src/api/adapters/authAdapter.ts
@@ -2,7 +2,7 @@
  * Адаптер для преобразования между интерфейсами аутентификации и сгенерированными моделями API
  */
 
-import { UserDto, LoginRequest, RegisterRequest } from '../generated/models';
+import { UserDto, LoginRequest, RegisterRequest, LoginResponse } from '../generated/models';
 
 import {
   User,
@@ -10,6 +10,7 @@ import {
   RegisterData,
   UpdateProfileData,
   ChangePasswordData,
+  AuthResponse,
 } from '@/modules/auth/types';
 
 /**
@@ -28,11 +29,25 @@ export function apiToUser(apiUser: UserDto): User {
 }
 
 /**
+ * Преобразует LoginResponse из API в AuthResponse для фронтенда
+ */
+export function loginResponseToAuth(response: LoginResponse): AuthResponse {
+  const data = response.data || {};
+  const user = data.user ? apiToUser(data.user) : ({} as User);
+
+  return {
+    user,
+    accessToken: data.accessToken || '',
+    refreshToken: data.refreshToken || '',
+  };
+}
+
+/**
  * Преобразует LoginData для фронтенда в LoginRequest для API
  */
 export function loginDataToApi(data: LoginData): LoginRequest {
   return {
-    email: data.email,
+    email: data.username,
     password: data.password,
     rememberMe: data.rememberMe,
   };
@@ -43,8 +58,8 @@ export function loginDataToApi(data: LoginData): LoginRequest {
  */
 export function registerDataToApi(data: RegisterData): RegisterRequest {
   return {
-    username: data.username ?? data.email,
-    email: data.email,
+    username: data.username,
+    email: data.username,
     password: data.password,
     displayName: data.displayName,
   };

--- a/frontend/src/modules/auth/__tests__/authApi.test.ts
+++ b/frontend/src/modules/auth/__tests__/authApi.test.ts
@@ -28,7 +28,7 @@ describe('authApi', () => {
   });
 
   describe('login', () => {
-    const loginData = { email: 'test@example.com', password: 'password123' };
+    const loginData = { username: 'test@example.com', password: 'password123' };
     const mockUser = {
       id: '1',
       email: 'test@example.com',
@@ -53,15 +53,16 @@ describe('authApi', () => {
 
       // Проверяем, что apiService.post вызван с правильными параметрами
       expect(apiService.post).toHaveBeenCalledWith('/auth/signin', {
-        username: loginData.email,
+        email: loginData.username,
         password: loginData.password,
+        rememberMe: undefined,
       });
     });
   });
 
   describe('register', () => {
     const registerData = {
-      email: 'test@example.com',
+      username: 'test@example.com',
       password: 'password123',
       displayName: 'Test User',
     };
@@ -90,9 +91,10 @@ describe('authApi', () => {
 
       // Проверяем, что apiService.post вызван с правильными параметрами
       expect(apiService.post).toHaveBeenCalledWith('/auth/register', {
-        name: 'Test User',
         username: 'test@example.com',
+        email: 'test@example.com',
         password: 'password123',
+        displayName: 'Test User',
       });
     });
   });
@@ -116,7 +118,7 @@ describe('authApi', () => {
 
   describe('updateProfile', () => {
     const userId = '1';
-    const profileData = { name: 'Updated Name', email: 'updated@example.com' };
+    const profileData = { displayName: 'Updated Name', avatar: 'avatar.png' };
 
     const mockResponse = {
       data: {

--- a/frontend/src/modules/auth/__tests__/authSlice.test.ts
+++ b/frontend/src/modules/auth/__tests__/authSlice.test.ts
@@ -45,9 +45,12 @@ describe('authSlice', () => {
   // Моковые данные пользователя
   const mockUser: User = {
     id: '1',
+    username: 'testuser',
     email: 'test@example.com',
-    name: 'Test User',
+    displayName: 'Test User',
     role: 'USER',
+    createdAt: '',
+    updatedAt: '',
   };
 
   describe('reducer', () => {
@@ -163,7 +166,7 @@ describe('authSlice', () => {
     it('should handle updateProfile.fulfilled', () => {
       const updatedUser = {
         ...mockUser,
-        name: 'Updated Name',
+        displayName: 'Updated Name',
       };
 
       const loggedInState = {

--- a/frontend/src/modules/auth/store/authSlice.ts
+++ b/frontend/src/modules/auth/store/authSlice.ts
@@ -11,6 +11,8 @@ import {
 } from '../types';
 
 import { ApiError } from '@/shared/types/api';
+import { loginResponseToAuth, apiToUser } from '@/api/adapters/authAdapter';
+import type { LoginResponse, UserDto } from '@/api/generated/models';
 
 // Начальное состояние
 const initialState: AuthState = {
@@ -27,25 +29,8 @@ export const login = createAsyncThunk(
   'auth/login',
   async (loginData: LoginData, { rejectWithValue }) => {
     try {
-      const response = await authApi.login(loginData);
-      const jwtRes = response.data.data as {
-        token: string;
-        id: string;
-        username: string;
-        name: string;
-        role: string;
-        refreshToken: string;
-      };
-      const accessToken = jwtRes.token;
-      const refreshToken = jwtRes.refreshToken || '';
-      const user: User = {
-        id: jwtRes.id,
-        username: jwtRes.username,
-        displayName: jwtRes.name,
-        role: jwtRes.role,
-        createdAt: '',
-        updatedAt: '',
-      } as unknown as User;
+      const response: LoginResponse = await authApi.login(loginData);
+      const { user, accessToken, refreshToken } = loginResponseToAuth(response);
 
       // Сохраняем токены в localStorage
       localStorage.setItem('accessToken', accessToken);
@@ -65,25 +50,8 @@ export const register = createAsyncThunk(
   'auth/register',
   async (registerData: RegisterData, { rejectWithValue }) => {
     try {
-      const response = await authApi.register(registerData);
-      const jwtRes = response.data.data as {
-        token: string;
-        id: string;
-        username: string;
-        name: string;
-        role: string;
-        refreshToken: string;
-      };
-      const accessToken = jwtRes.token;
-      const refreshToken = jwtRes.refreshToken || '';
-      const user: User = {
-        id: jwtRes.id,
-        username: jwtRes.username,
-        displayName: jwtRes.name,
-        role: jwtRes.role,
-        createdAt: '',
-        updatedAt: '',
-      } as unknown as User;
+      const response: LoginResponse = await authApi.register(registerData);
+      const { user, accessToken, refreshToken } = loginResponseToAuth(response);
 
       // Сохраняем токены в localStorage
       localStorage.setItem('accessToken', accessToken);
@@ -129,7 +97,7 @@ export const updateProfile = createAsyncThunk(
   ) => {
     try {
       const response = await authApi.updateProfile(userId, profileData);
-      const updatedUser = response.data.data;
+      const updatedUser: User = apiToUser(response.data as UserDto);
 
       // Обновляем данные пользователя в localStorage
       localStorage.setItem('user', JSON.stringify(updatedUser));


### PR DESCRIPTION
## Summary
- integrate generated `LoginResponse` and `UserDto` models in auth flow
- add adapter for converting OpenAPI auth responses to frontend types
- update tests and request converters for typed payloads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894b282e78c83229ecedc91291ab5aa