### PR TITLE
Disable OpenJDK class sharing warnings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,8 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Xshare:off -Dorg.openapitoo
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.caching=true
-org.gradle.configureondemand=true
+# Disabled to avoid incubating feature warning
+org.gradle.configureondemand=false
 
 # Suppress Gradle deprecation warnings (should be addressed gradually)
 org.gradle.warning.mode=none

--- a/gradlew
+++ b/gradlew
@@ -86,7 +86,9 @@ APP_NAME="Gradle"
 APP_BASE_NAME=${0##*/}
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+# Disable OpenJDK class data sharing warnings in all JVMs
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m" "-Xshare:off"'
+export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xshare:off"
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
## Summary
- disable OpenJDK class data sharing across Gradle builds to remove JVM warnings
- remove incubating configure-on-demand mode to silence Gradle message

## Testing
- `./run.sh build -be`
- `./run.sh test -be`


------
https://chatgpt.com/codex/tasks/task_e_6894b7dc3d98832298f4b24d33ef6aa3