### PR TITLE
Add email input to registration flow

### DIFF
--- a/frontend/src/api/adapters/authAdapter.ts
+++ b/frontend/src/api/adapters/authAdapter.ts
@@ -59,7 +59,7 @@ export function loginDataToApi(data: LoginData): LoginRequest {
 export function registerDataToApi(data: RegisterData): RegisterRequest {
   return {
     username: data.username,
-    email: data.username,
+    email: data.email,
     password: data.password,
     displayName: data.displayName,
   };

--- a/frontend/src/modules/auth/__tests__/authApi.test.ts
+++ b/frontend/src/modules/auth/__tests__/authApi.test.ts
@@ -62,7 +62,8 @@ describe('authApi', () => {
 
   describe('register', () => {
     const registerData = {
-      username: 'test@example.com',
+      username: 'testuser',
+      email: 'test@example.com',
       password: 'password123',
       displayName: 'Test User',
     };
@@ -91,7 +92,7 @@ describe('authApi', () => {
 
       // Проверяем, что apiService.post вызван с правильными параметрами
       expect(apiService.post).toHaveBeenCalledWith('/auth/register', {
-        username: 'test@example.com',
+        username: 'testuser',
         email: 'test@example.com',
         password: 'password123',
         displayName: 'Test User',

--- a/frontend/src/modules/auth/types.ts
+++ b/frontend/src/modules/auth/types.ts
@@ -11,6 +11,7 @@ export enum UserRole {
 export interface User {
   id: string | number;
   username: string;
+  email?: string;
   name?: string;
   displayName?: string;
   avatar?: string;
@@ -32,6 +33,7 @@ export interface LoginData {
 // Данные для регистрации
 export interface RegisterData {
   username: string;
+  email: string;
   password: string;
   displayName?: string;
   name?: string;

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -16,6 +16,7 @@ const registerSchema = z
       .string()
       .min(3, 'Логин должен содержать минимум 3 символа')
       .regex(/^[a-zA-Z0-9_.-]+$/, 'Логин может содержать только буквы, цифры и знаки _.-'),
+    email: z.string().email('Введите корректный email'),
     password: z.string().min(6, 'Пароль должен содержать минимум 6 символов'),
     confirmPassword: z.string(),
   })
@@ -41,6 +42,7 @@ const RegisterPage: React.FC = () => {
       await dispatch(
         registerThunk({
           username: data.username,
+          email: data.email,
           password: data.password,
           name: data.name,
           displayName: data.name,
@@ -95,6 +97,20 @@ const RegisterPage: React.FC = () => {
                 {...field}
                 error={fieldState.error?.message}
                 helperText="Будет использоваться для входа в систему"
+                fullWidth
+              />
+            )}
+          />
+          {/* Поле email */}
+          <FormField
+            name="email"
+            render={({ field, fieldState }) => (
+              <Input
+                label="Email"
+                placeholder="Введите ваш email"
+                type="email"
+                {...field}
+                error={fieldState.error?.message}
                 fullWidth
               />
             )}


### PR DESCRIPTION
## Summary
- capture email separately on registration form
- map email to API in register adapter
- update auth API tests for email handling

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c35967d88322aaa7153f09bbe7ef