### PR TITLE
refactor: use AuthService for auth

### DIFF
--- a/frontend/config/vite/dev.config.ts
+++ b/frontend/config/vite/dev.config.ts
@@ -18,6 +18,12 @@ export default ({ mode }) => {
         usePolling: true,
         interval: 1000,
       },
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+        },
+      },
     },
     test: {
       globals: true,

--- a/frontend/src/api/generated/core/OpenAPI.ts
+++ b/frontend/src/api/generated/core/OpenAPI.ts
@@ -20,7 +20,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-  BASE: 'http://localhost:8080',
+  BASE: '/api',
   VERSION: '1.0.0',
   WITH_CREDENTIALS: false,
   CREDENTIALS: 'include',

--- a/frontend/src/api/generated/services/AuthService.ts
+++ b/frontend/src/api/generated/services/AuthService.ts
@@ -24,7 +24,7 @@ export class AuthService {
   }): CancelablePromise<LoginResponse> {
     return __request(OpenAPI, {
       method: 'POST',
-      url: '/api/auth/login',
+      url: '/auth/login',
       body: requestBody,
       mediaType: 'application/json',
       errors: {
@@ -47,7 +47,7 @@ export class AuthService {
   }): CancelablePromise<LoginResponse> {
     return __request(OpenAPI, {
       method: 'POST',
-      url: '/api/auth/register',
+      url: '/auth/register',
       body: requestBody,
       mediaType: 'application/json',
       errors: {

--- a/frontend/src/modules/auth/__tests__/authApi.test.ts
+++ b/frontend/src/modules/auth/__tests__/authApi.test.ts
@@ -1,11 +1,10 @@
-import { setupServer } from 'msw/node';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { authApi } from '../api/authApi';
 
 import { apiService } from '@/services';
-import { API_URL } from '@/shared/config/constants';
-import { server } from '@/test/setup';
+import { AuthService } from '@/api/generated/services/AuthService';
+import type { LoginResponse } from '@/api/generated/models';
 
 // Мокируем apiService для тестов
 vi.mock('@/services', () => ({
@@ -19,6 +18,13 @@ vi.mock('@/services', () => ({
     error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
+  },
+}));
+
+vi.mock('@/api/generated/services/AuthService', () => ({
+  AuthService: {
+    login: vi.fn(),
+    register: vi.fn(),
   },
 }));
 
@@ -45,17 +51,19 @@ describe('authApi', () => {
       message: 'Login successful',
     };
 
-    it('should call apiService.post with correct parameters', async () => {
-      // Мокируем apiService.post для возврата ожидаемого ответа
-      vi.mocked(apiService.post).mockResolvedValueOnce({ data: mockResponse });
+    it('should call AuthService.login with correct parameters', async () => {
+      vi.mocked(AuthService.login).mockResolvedValueOnce(
+        mockResponse as LoginResponse
+      );
 
       await authApi.login(loginData);
 
-      // Проверяем, что apiService.post вызван с правильными параметрами
-      expect(apiService.post).toHaveBeenCalledWith('/auth/signin', {
-        email: loginData.username,
-        password: loginData.password,
-        rememberMe: undefined,
+      expect(AuthService.login).toHaveBeenCalledWith({
+        requestBody: {
+          email: loginData.username,
+          password: loginData.password,
+          rememberMe: undefined,
+        },
       });
     });
   });
@@ -83,18 +91,20 @@ describe('authApi', () => {
       message: 'Registration successful',
     };
 
-    it('should call apiService.post with correct parameters', async () => {
-      // Мокируем apiService.post для возврата ожидаемого ответа
-      vi.mocked(apiService.post).mockResolvedValueOnce({ data: mockResponse });
+    it('should call AuthService.register with correct parameters', async () => {
+      vi.mocked(AuthService.register).mockResolvedValueOnce(
+        mockResponse as LoginResponse
+      );
 
       await authApi.register(registerData);
 
-      // Проверяем, что apiService.post вызван с правильными параметрами
-      expect(apiService.post).toHaveBeenCalledWith('/auth/register', {
-        username: 'test@example.com',
-        email: 'test@example.com',
-        password: 'password123',
-        displayName: 'Test User',
+      expect(AuthService.register).toHaveBeenCalledWith({
+        requestBody: {
+          username: 'test@example.com',
+          email: 'test@example.com',
+          password: 'password123',
+          displayName: 'Test User',
+        },
       });
     });
   });

--- a/frontend/src/modules/auth/api/authApi.ts
+++ b/frontend/src/modules/auth/api/authApi.ts
@@ -14,7 +14,8 @@ import {
   updateProfileToApi,
   changePasswordToApi,
 } from '@/api/adapters/authAdapter';
-import type { LoginRequest, RegisterRequest, LoginResponse, UserDto } from '@/api/generated/models';
+import type { UserDto } from '@/api/generated/models';
+import { AuthService } from '@/api/generated/services/AuthService';
 
 /**
  * API для работы с аутентификацией
@@ -26,10 +27,9 @@ export const authApi = {
    */
   login: (loginData: LoginData) => {
     logger.debug('Logging in user', { username: loginData.username });
-    return apiService.post<LoginResponse, LoginRequest>(
-      '/auth/signin',
-      loginDataToApi(loginData)
-    );
+    return AuthService.login({
+      requestBody: loginDataToApi(loginData),
+    });
   },
 
   /**
@@ -38,10 +38,9 @@ export const authApi = {
    */
   register: (registerData: RegisterData) => {
     logger.debug('Registering new user', { username: registerData.username });
-    return apiService.post<LoginResponse, RegisterRequest>(
-      '/auth/register',
-      registerDataToApi(registerData)
-    );
+    return AuthService.register({
+      requestBody: registerDataToApi(registerData),
+    });
   },
 
   /**

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
   ],
   root: '.',
   publicDir: 'public',
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
   build: {
     outDir: 'dist',
     cssCodeSplit: true,


### PR DESCRIPTION
## Summary
- switch auth API login/registration to generated AuthService
- set OpenAPI base URL to /api and update endpoints
- add Vite dev proxy for `/api`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint found too many warnings)*
- `npx eslint src/modules/auth --max-warnings 0`

------
https://chatgpt.com/codex/tasks/task_e_6894c34b48f48322bc00358e52218249