### PR TITLE
refactor(frontend): remove custom styles in favour of Tailwind

### DIFF
--- a/frontend/src/components/EventCard/ParticipantsProgress.tsx
+++ b/frontend/src/components/EventCard/ParticipantsProgress.tsx
@@ -1,4 +1,5 @@
 import { cn } from '../../utils/cn';
+import { motion } from 'framer-motion';
 
 /**
  * Свойства индикатора прогресса участников
@@ -47,9 +48,11 @@ const ParticipantsProgress = ({
         <span data-testid="participants-percentage">{percentage}%</span>
       </div>
       <div className="h-2 w-full bg-gray-200 rounded-full overflow-hidden">
-        <div
-          className={cn("h-full transition-all duration-300", progressColor)} // Используем фиксированный цвет
-          style={{ width: `${percentage}%` }}
+        <motion.div
+          className={cn('h-full', progressColor)}
+          initial={{ width: 0 }}
+          animate={{ width: `${percentage}%` }}
+          transition={{ duration: 0.3 }}
           data-testid="progress-bar"
         />
       </div>

--- a/frontend/src/components/layout/Header/HeaderScroll.tsx
+++ b/frontend/src/components/layout/Header/HeaderScroll.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import React, { useState, useEffect, useRef, useCallback, useMemo, createContext } from 'react';
+import { cn } from '@utils/cn';
 import { useLocation } from 'react-router-dom';
 
 /**
@@ -76,10 +77,6 @@ interface HeaderScrollProps {
    */
   headerRef?: React.RefObject<HTMLDivElement>;
   /**
-   * Стиль для заголовка
-   */
-  style?: React.CSSProperties;
-  /**
    * Дополнительные CSS-классы
    */
   className?: string;
@@ -93,7 +90,6 @@ const HeaderScroll: React.FC<HeaderScrollProps> = React.memo(({
   scrollSettings: customScrollSettings,
   animationSettings: customAnimationSettings,
   headerRef: externalHeaderRef,
-  style,
   className,
 }) => {
   // Состояние видимости заголовка
@@ -244,10 +240,13 @@ const HeaderScroll: React.FC<HeaderScrollProps> = React.memo(({
     <MenuContext.Provider value={{ isMenuOpen, setMenuOpen }}>
       <motion.header
         ref={headerRef}
-        className={`fixed top-0 left-0 right-0 z-50 flex justify-center pt-6 px-4 ${className || ''}`}
+        className={cn(
+          'fixed top-0 left-0 right-0 z-50 flex justify-center pt-6 px-4 h-[85px]',
+          className
+        )}
         initial={{ y: 0, opacity: 1 }}
-        animate={{ 
-          y: isVisible ? 0 : '-100%', 
+        animate={{
+          y: isVisible ? 0 : '-100%',
           opacity: isVisible ? 1 : 0.5,
         }}
         transition={{ 
@@ -260,10 +259,6 @@ const HeaderScroll: React.FC<HeaderScrollProps> = React.memo(({
           opacity: { 
             duration: animationSettings.opacityDuration
           }
-        }}
-        style={{
-          height: 'var(--header-height, 85px)',
-          ...style,
         }}
         data-testid="header-scroll"
       >

--- a/frontend/src/components/ui/Button/Button.stories.tsx
+++ b/frontend/src/components/ui/Button/Button.stories.tsx
@@ -141,11 +141,11 @@ export const WithIcons: Story = {
     variant: 'primary',
     children: (
       <>
-        <span role="img" aria-label="rocket" style={{ marginRight: '8px' }}>
+        <span role="img" aria-label="rocket" className="mr-2">
           🚀
         </span>
         Кнопка с иконками
-        <span role="img" aria-label="thumbs up" style={{ marginLeft: '8px' }}>
+        <span role="img" aria-label="thumbs up" className="ml-2">
           👍
         </span>
       </>

--- a/frontend/src/components/ui/LazyImage/LazyImage.tsx
+++ b/frontend/src/components/ui/LazyImage/LazyImage.tsx
@@ -33,9 +33,9 @@ const objectFitClasses: Record<ObjectFitMode, string> = {
 const fadeAnimationClasses: Record<FadeInAnimation, string> = {
   none: '',
   fade: 'transition-opacity duration-500 ease-in-out',
-  zoom: 'transition-transform duration-500 ease-in-out scale-95 opacity-0 loaded:scale-100 loaded:opacity-100',
-  blur: 'transition-all duration-500 ease-in-out filter blur-sm opacity-0 loaded:blur-0 loaded:opacity-100',
-  'slide-up': 'transition-all duration-500 ease-in-out transform translate-y-4 opacity-0 loaded:translate-y-0 loaded:opacity-100',
+  zoom: 'transition-transform duration-500 ease-in-out scale-95 opacity-0',
+  blur: 'transition-all duration-500 ease-in-out filter blur-sm opacity-0',
+  'slide-up': 'transition-all duration-500 ease-in-out transform translate-y-4 opacity-0',
 };
 
 // Эффекты при наведении
@@ -53,11 +53,8 @@ const hoverEffectClasses: Record<HoverEffect, string> = {
 export const LazyImage: React.FC<LazyImageProps> = ({
   src,
   alt,
-  width,
-  height,
   placeholderColor = 'bg-secondary-200 dark:bg-secondary-700',
   className = '',
-  style = {},
   lowQualityPreview = false,
   previewSrc,
   onLoad,
@@ -67,7 +64,6 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   rounded = 'md',
   shadow = 'none',
   fadeAnimation = 'fade',
-  animationDuration = 500,
   hoverEffect = 'none',
   showPreloader = true,
   fallbackSrc,
@@ -143,24 +139,15 @@ export const LazyImage: React.FC<LazyImageProps> = ({
     setIsError(false);
   }, [src, loading]);
 
-  // Вычисляем инлайн-стили для контейнера
-  const containerStyles: React.CSSProperties = {
-    width: width,
-    height: height,
-    ...style,
-  };
-
   // Определяем классы для контейнера
   const containerClasses = cn(
-    'lazy-image-container relative inline-block overflow-hidden align-top',
+    'relative inline-block overflow-hidden align-top',
     placeholderColor,
     roundedClasses[rounded],
     shadowClasses[shadow],
     hoverEffect === 'lift' && hoverEffectClasses[hoverEffect],
     className,
     {
-      'lazy-image-loaded': isLoaded,
-      'lazy-image-error': isError,
       'cursor-pointer': onClick,
     }
   );
@@ -171,7 +158,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
     objectFitClasses[objectFit],
     fadeAnimationClasses[fadeAnimation],
     (hoverEffect === 'zoom' || hoverEffect === 'brightness' || hoverEffect === 'scale') && hoverEffectClasses[hoverEffect],
-    isLoaded ? 'opacity-100 loaded' : 'opacity-0'
+    isLoaded ? 'opacity-100 scale-100 blur-0 translate-y-0' : 'opacity-0'
   );
 
   // Классы для прелоадера
@@ -201,7 +188,6 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   return (
     <div
       className={containerClasses}
-      style={containerStyles}
       data-testid="lazy-image-container"
       onClick={onClick}
       onKeyDown={handleKeyPress}
@@ -249,7 +235,6 @@ export const LazyImage: React.FC<LazyImageProps> = ({
         onError={handleImageError}
         loading={loading === 'lazy' ? 'lazy' : undefined}
         data-testid="lazy-image-img"
-        style={{ transitionDuration: `${animationDuration}ms` }}
       />
     </div>
   );

--- a/frontend/src/components/ui/LazyImage/types.ts
+++ b/frontend/src/components/ui/LazyImage/types.ts
@@ -1,5 +1,4 @@
-import React from 'react';
-
+import type React from 'react';
 /**
  * Доступные методы загрузки изображений
  */
@@ -38,16 +37,10 @@ export interface LazyImageProps {
   src: string;
   /** Альтернативный текст */
   alt: string;
-  /** Ширина изображения */
-  width?: number | string;
-  /** Высота изображения */
-  height?: number | string;
   /** Цвет placeholder'а до загрузки изображения */
   placeholderColor?: string;
   /** CSS-класс */
   className?: string;
-  /** Инлайн-стили */
-  style?: React.CSSProperties;
   /** Загружать изображение с низким разрешением */
   lowQualityPreview?: boolean;
   /** URL изображения с низким разрешением */
@@ -66,8 +59,6 @@ export interface LazyImageProps {
   shadow?: ShadowSize;
   /** Тип анимации появления */
   fadeAnimation?: FadeInAnimation;
-  /** Длительность анимации в мс */
-  animationDuration?: number;
   /** Эффект при наведении */
   hoverEffect?: HoverEffect;
   /** Показывать прелоадер */

--- a/frontend/src/components/ui/Modal/Modal.tsx
+++ b/frontend/src/components/ui/Modal/Modal.tsx
@@ -107,7 +107,7 @@ export const Modal: React.FC<ModalProps> = ({
     <div
       ref={backdropRef}
       onClick={handleBackdropClick}
-      className="modal-backdrop"
+      className="fixed inset-0 flex items-center justify-center bg-black/50"
       role="presentation"
       data-testid="modal-backdrop"
     >

--- a/frontend/src/pages/UIKitPage/UIKitPage.tsx
+++ b/frontend/src/pages/UIKitPage/UIKitPage.tsx
@@ -414,8 +414,7 @@ const LazyImageSection = () => {
           <LazyImage
             src="https://images.unsplash.com/photo-1583608205776-bfd35f0d9f83?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80"
             alt="Горы и река"
-            width="100%"
-            height="200px"
+            className="w-full h-[200px]"
             rounded="md"
             shadow="md"
             fadeAnimation="fade"
@@ -427,8 +426,7 @@ const LazyImageSection = () => {
           <LazyImage
             src="https://images.unsplash.com/photo-1519681393784-d120267933ba?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80"
             alt="Звездное небо"
-            width="100%"
-            height="200px"
+            className="w-full h-[200px]"
             rounded="lg"
             shadow="lg"
             fadeAnimation="blur"
@@ -441,8 +439,7 @@ const LazyImageSection = () => {
           <LazyImage
             src="https://images.unsplash.com/photo-1588392382834-a891154bca4d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80"
             alt="Горный пейзаж"
-            width="100%"
-            height="200px"
+            className="w-full h-[200px]"
             rounded="xl"
             shadow="sm"
             fadeAnimation="zoom"

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,19 +1,9 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  darkMode: ["class"],
-  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-  plugins: [
-    function ({ addUtilities }) {
-      addUtilities({
-        ".loaded": {
-          opacity: "1",
-          transform: "scale(1)",
-          filter: "blur(0)",
-        },
-      });
-    },
-  ],
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  plugins: [],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- replace leftover inline styles with Tailwind utilities
- drop custom Modal backdrop class for Tailwind overlay
- simplify LazyImage API to use Tailwind classes for sizing

## Testing
- `npm test` (fails: AuthService.register expected args mismatch)


------
https://chatgpt.com/codex/tasks/task_e_6894e785d4148322a44463fbfbe70810