### PR TITLE
Remove main-content class from MainLayout

### DIFF
--- a/frontend/src/components/layout/MainLayout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout/MainLayout.tsx
@@ -13,7 +13,7 @@ interface MainLayoutProps {
 export const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
   return (
     <main
-      className="main-content flex-1 pb-8 bg-gray-50 dark:bg-gray-900"
+      className="flex-1 pb-8 bg-gray-50 dark:bg-gray-900"
       data-testid="main-layout"
     >
       <div className="container max-w-full md:max-w-screen-md mx-auto px-4">{children}</div>


### PR DESCRIPTION
## Summary
- remove unused `main-content` class from MainLayout component

## Testing
- `npm test` *(fails: authApi register argument mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6894f00eeb4c8322b3475bd1693f856a