### PR TITLE
fix: use text-current for spinner

### DIFF
--- a/frontend/src/components/ui/Button/Button.tsx
+++ b/frontend/src/components/ui/Button/Button.tsx
@@ -6,7 +6,7 @@ import { ButtonProps, ButtonSize } from './Button.types';
 // Добавляем компонент спиннера для состояния loading
 const Spinner: React.FC<{ sizeClass: string }> = ({ sizeClass }) => (
   <svg
-    className={`animate-spin -ml-1 mr-3 ${sizeClass} text-currentColor`}
+    className={`animate-spin -ml-1 mr-3 ${sizeClass} text-current`}
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- fix spinner text color class to text-current

## Testing
- `npm test` *(fails: authApi register test expectation mismatch)*
- `npm run storybook -- --ci`


------
https://chatgpt.com/codex/tasks/task_e_6894f019362083229a547a84d4b6c86f