### PR TITLE
fix(frontend): remove duplicate border radius in header

### DIFF
--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -79,7 +79,7 @@ const Header: React.FC<HeaderProps> = ({
         opacityDuration: 0.15,
       }}
     >
-      <div className="flex items-center justify-between w-auto max-w-screen-xl mx-auto rounded-[15px] shadow-md px-5 py-3 transition-colors bg-[#1E2841] rounded-xl">
+        <div className="flex items-center justify-between w-auto max-w-screen-xl mx-auto shadow-md px-5 py-3 transition-colors bg-[#1E2841] rounded-2xl">
         {/* Логотип */}
         <div className="flex-shrink-0 mr-6">
           <Logo onClick={closeMenu} />


### PR DESCRIPTION
## Summary
- use single border-radius class in Header component

## Testing
- `npm test` *(fails: expected spy to be called with arguments)*
- `npm run lint` *(fails: ESLint found too many warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894f02c5520832289dcdcc83e8a55e8