### PR TITLE
refactor: add theme context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,47 +1,20 @@
-import { Suspense, useState, useEffect } from 'react';
+import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import Layout from '@/components/layout/Layout';
 import { PageLoader } from '@/components/ui';
 import { useAppSelector } from '@/hooks/redux';
 import { selectUserState } from '@/store/slices/userSlice';
-import { initializeTheme } from '@/theme';
+import { useTheme } from '@/providers/ThemeProvider';
 
 const App = () => {
-  const [darkMode, setDarkMode] = useState(false);
+  const { theme } = useTheme();
   const userState = useAppSelector(selectUserState);
   const isAuthenticated = !!userState.currentUser;
 
-  // Получаем тему из localStorage при загрузке
-  useEffect(() => {
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark') {
-      setDarkMode(true);
-    }
-  }, []);
-
-  // Инициализация темы и удаление обработчиков при размонтировании
-  useEffect(() => {
-    const cleanup = initializeTheme();
-    return () => {
-      cleanup && cleanup();
-    };
-  }, []);
-
-  const toggleTheme = () => {
-    setDarkMode(!darkMode);
-    // Сохраняем выбор темы в localStorage
-    localStorage.setItem('theme', !darkMode ? 'dark' : 'light');
-  };
-
   return (
-    <div className={darkMode ? 'dark' : ''}>
-      <Layout 
-        toggleTheme={toggleTheme} 
-        headerAppearEffect="fade-in"
-        isAuthenticated={isAuthenticated}
-        theme={darkMode ? 'dark' : 'light'}
-      >
+    <div className={theme === 'dark' ? 'dark' : ''}>
+      <Layout headerAppearEffect="fade-in" isAuthenticated={isAuthenticated}>
         <Suspense fallback={<PageLoader />}>
           <Outlet />
         </Suspense>

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -1,6 +1,6 @@
 import { Calendar, Users, HelpCircle } from 'lucide-react';
 import React, { useCallback, useContext } from 'react';
-
+import { Calendar, Users, HelpCircle } from 'lucide-react';
 
 import HeaderScroll, { MenuContext } from './HeaderScroll';
 import Logo from './Logo';
@@ -12,8 +12,6 @@ import { NavItem, HeaderProps } from './types';
  * Компонент Header - шапка сайта с навигацией и логотипом
  */
 const Header: React.FC<HeaderProps> = ({
-  onThemeToggle,
-  theme = 'light',
   isAuthenticated = false,
   items,
   navItems,
@@ -87,24 +85,20 @@ const Header: React.FC<HeaderProps> = ({
 
         {/* Десктопное меню */}
         <div className="hidden md:block">
-          <NavigationMenu
+      <NavigationMenu
             items={menuItems}
-            theme={theme}
             isAuthenticated={isAuthenticated}
             mode="text"
-            onThemeToggle={onThemeToggle}
             renderIcon={renderIcon}
           />
         </div>
 
         {/* Мобильное меню (иконки) */}
         <div className="md:hidden">
-          <NavigationMenu
+      <NavigationMenu
             items={menuItems}
-            theme={theme}
             isAuthenticated={isAuthenticated}
             mode="icon"
-            onThemeToggle={onThemeToggle}
             renderIcon={renderIcon}
           />
         </div>

--- a/frontend/src/components/layout/Header/NavigationMenu.tsx
+++ b/frontend/src/components/layout/Header/NavigationMenu.tsx
@@ -18,10 +18,6 @@ interface NavigationMenuProps {
    */
   items: NavItem[];
   /**
-   * Текущая тема
-   */
-  theme: 'light' | 'dark';
-  /**
    * Статус авторизации пользователя
    */
   isAuthenticated: boolean;
@@ -29,10 +25,6 @@ interface NavigationMenuProps {
    * Режим отображения (текст, иконки или оба)
    */
   mode?: 'text' | 'icon' | 'both';
-  /**
-   * Обработчик переключения темы
-   */
-  onThemeToggle?: () => void;
   /**
    * Функция для рендеринга иконок
    */
@@ -48,10 +40,8 @@ interface NavigationMenuProps {
  */
 const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(({
   items,
-  theme,
   isAuthenticated,
   mode = 'text',
-  onThemeToggle,
   renderIcon,
   className,
 }) => {
@@ -110,7 +100,7 @@ const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(({
       />
 
       {/* Переключатель темы */}
-      <ThemeSwitcher theme={theme} onToggle={onThemeToggle} />
+      <ThemeSwitcher />
     </nav>
   );
 });

--- a/frontend/src/components/layout/Header/ThemeSwitcher.tsx
+++ b/frontend/src/components/layout/Header/ThemeSwitcher.tsx
@@ -1,19 +1,12 @@
 import { Sun, Moon } from 'lucide-react';
 import React from 'react';
 
+import { useTheme } from '@/providers/ThemeProvider';
 
 /**
  * Свойства компонента переключателя темы
  */
 interface ThemeSwitcherProps {
-  /**
-   * Текущая тема
-   */
-  theme: 'light' | 'dark';
-  /**
-   * Обработчик переключения темы
-   */
-  onToggle?: () => void;
   /**
    * Дополнительные CSS-классы
    */
@@ -23,19 +16,16 @@ interface ThemeSwitcherProps {
 /**
  * Компонент для переключения между светлой и темной темами
  */
-const ThemeSwitcher: React.FC<ThemeSwitcherProps> = React.memo(({
-  theme,
-  onToggle,
-  className,
-}) => {
+const ThemeSwitcher: React.FC<ThemeSwitcherProps> = React.memo(({ className }) => {
+  const { theme, toggleTheme } = useTheme();
   const themeTitle = theme === 'dark' ? 'Светлая тема' : 'Темная тема';
-  
+
   return (
     <button
       type="button"
       aria-label="Переключить тему"
       className={`p-2 rounded-full transition-colors text-gray-300 hover:text-primary hover:bg-secondary/60 ${className || ''}`}
-      onClick={onToggle}
+      onClick={toggleTheme}
       title={themeTitle}
       data-testid="theme-switcher"
     >
@@ -50,4 +40,4 @@ const ThemeSwitcher: React.FC<ThemeSwitcherProps> = React.memo(({
 
 ThemeSwitcher.displayName = 'ThemeSwitcher';
 
-export default ThemeSwitcher; 
+export default ThemeSwitcher;

--- a/frontend/src/components/layout/Header/types.ts
+++ b/frontend/src/components/layout/Header/types.ts
@@ -36,16 +36,6 @@ export interface HeaderBaseProps {
 }
 
 /**
- * Свойства, связанные с темой
- */
-export interface HeaderThemeProps {
-  /** Функция переключения темы */
-  onThemeToggle?: () => void;
-  /** Текущая тема */
-  theme?: 'light' | 'dark';
-}
-
-/**
  * Свойства аутентификации
  */
 export interface HeaderAuthProps {
@@ -66,9 +56,7 @@ export interface HeaderNavigationProps {
 }
 
 /**
+ */
  * Полные свойства компонента Header
  */
-export type HeaderProps = HeaderBaseProps & 
-  HeaderThemeProps & 
-  HeaderAuthProps & 
-  HeaderNavigationProps;
+export type HeaderProps = HeaderBaseProps & HeaderAuthProps & HeaderNavigationProps;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -9,25 +9,20 @@ import { MainLayout } from './MainLayout/MainLayout';
 
 interface LayoutProps {
   children: ReactNode;
-  toggleTheme: () => void;
   /** Эффект появления шапки */
   headerAppearEffect?: 'none' | 'fade-in' | 'slide-up' | 'slide-down';
   /** Статус авторизации пользователя */
   isAuthenticated?: boolean;
-  /** Текущая тема */
-  theme?: 'light' | 'dark';
 }
 
 const Layout: React.FC<LayoutProps> = ({
   children,
-  toggleTheme,
   headerAppearEffect: _headerAppearEffect = 'none',
   isAuthenticated = false,
-  theme = 'light',
 }) => {
   return (
     <div className="flex flex-col min-h-screen">
-      <Header onThemeToggle={toggleTheme} isAuthenticated={isAuthenticated} theme={theme} />
+      <Header isAuthenticated={isAuthenticated} />
       <MainLayout>{children}</MainLayout>
       <Footer />
     </div>

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 
 
 import Header from '../Header/Header';
+import { ThemeProvider } from '@/providers/ThemeProvider';
 
 import { renderWithProviders } from '@/test/utils';
 
@@ -33,12 +34,15 @@ describe('Header Component', () => {
   // Очищаем DOM после каждого теста
   afterEach(() => {
     cleanup();
+    localStorage.clear();
   });
 
   it('renders with navigation items and theme toggle button', () => {
     renderWithProviders(
       <MemoryRouter>
-        <Header navItems={mockNavItems} theme="light" />
+        <ThemeProvider>
+          <Header navItems={mockNavItems} />
+        </ThemeProvider>
       </MemoryRouter>
     );
 
@@ -58,7 +62,9 @@ describe('Header Component', () => {
     // Проверяем темную тему
     const { unmount } = renderWithProviders(
       <MemoryRouter>
-        <Header navItems={mockNavItems} theme="dark" />
+        <ThemeProvider defaultTheme="dark">
+          <Header navItems={mockNavItems} />
+        </ThemeProvider>
       </MemoryRouter>
     );
 
@@ -68,11 +74,14 @@ describe('Header Component', () => {
     // Размонтируем компонент и очищаем DOM
     unmount();
     cleanup();
+    localStorage.clear();
 
     // Проверяем светлую тему
     renderWithProviders(
       <MemoryRouter>
-        <Header navItems={mockNavItems} theme="light" />
+        <ThemeProvider>
+          <Header navItems={mockNavItems} />
+        </ThemeProvider>
       </MemoryRouter>
     );
 
@@ -80,29 +89,28 @@ describe('Header Component', () => {
     expect(darkIcon).toBeInTheDocument();
   });
 
-  it('calls onThemeToggle when theme button is clicked', async () => {
-    const handleThemeToggle = vi.fn();
-
+  it('toggles theme when theme button is clicked', async () => {
     renderWithProviders(
       <MemoryRouter>
-        <Header navItems={mockNavItems} theme="light" onThemeToggle={handleThemeToggle} />
+        <ThemeProvider>
+          <Header navItems={mockNavItems} />
+        </ThemeProvider>
       </MemoryRouter>
     );
 
-    // Находим кнопку смены темы
     const themeToggleButton = screen.getAllByTestId('theme-switcher')[0];
-
-    // Используем userEvent.click для имитации клика
     await userEvent.click(themeToggleButton);
 
-    // Проверяем, что обработчик был вызван
-    expect(handleThemeToggle).toHaveBeenCalledTimes(1);
+    const lightIcon = screen.getAllByTestId('light-icon')[0];
+    expect(lightIcon).toBeInTheDocument();
   });
 
   it('renders correct navigation links with href attributes', () => {
     renderWithProviders(
       <MemoryRouter>
-        <Header navItems={mockNavItems} theme="light" />
+        <ThemeProvider>
+          <Header navItems={mockNavItems} />
+        </ThemeProvider>
       </MemoryRouter>
     );
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom'
 import App from './App';
 import './main.css';
 import store from './store';
+import { ThemeProvider } from '@/providers/ThemeProvider';
 
 import { PageLoader } from '@/components/ui';
 import { useAuth } from '@/modules/auth/hooks/useAuth';
@@ -43,7 +44,9 @@ const router = createBrowserRouter([
     path: '/',
     element: (
       <HelmetProvider>
-        <App />
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
       </HelmetProvider>
     ),
     children: [

--- a/frontend/src/providers/ThemeProvider.tsx
+++ b/frontend/src/providers/ThemeProvider.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+import { storeTheme, applyTheme, initializeTheme, getSystemTheme } from '@/theme';
+import type { Theme } from '@/theme';
+
+interface ThemeContextValue {
+  theme: 'light' | 'dark';
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+interface ThemeProviderProps {
+  children: ReactNode;
+  defaultTheme?: Theme;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, defaultTheme = 'light' }) => {
+  const [theme, setThemeState] = useState<'light' | 'dark'>(defaultTheme === 'system' ? getSystemTheme() : defaultTheme);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    const initial = stored || defaultTheme;
+    setTheme(initial);
+    const cleanup = initializeTheme();
+    return () => {
+      cleanup && cleanup();
+    };
+  }, [defaultTheme]);
+
+  const setTheme = (newTheme: Theme) => {
+    storeTheme(newTheme);
+    applyTheme(newTheme);
+    setThemeState(newTheme === 'system' ? getSystemTheme() : newTheme);
+  };
+
+  const toggleTheme = () => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  };
+
+  return <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+};
+
+export default ThemeProvider;


### PR DESCRIPTION
## Summary
- add ThemeProvider context to manage and toggle light/dark theme
- remove dark mode state and localStorage handling from App and Layout
- update header components to consume theme from context

## Testing
- `npm test` *(fails: authApi.test.ts should call AuthService.register with correct parameters)*
- `npm test src/components/layout/__tests__/Header.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6894f528277c8322bfe2fa4e040a0d0f