### PR TITLE
fix: remove duplicate lucide-react import

### DIFF
--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -1,6 +1,5 @@
 import { Calendar, Users, HelpCircle } from 'lucide-react';
 import React, { useCallback, useContext } from 'react';
-import { Calendar, Users, HelpCircle } from 'lucide-react';
 
 import HeaderScroll, { MenuContext } from './HeaderScroll';
 import Logo from './Logo';


### PR DESCRIPTION
## Summary
- remove duplicated lucide-react import in Header component

## Testing
- `npm test` *(fails: authApi.test.ts)*
- `npm run lint` *(fails: parse error in Header/types.ts and `no-explicit-any` warnings in events modules)*

------
https://chatgpt.com/codex/tasks/task_e_6895020ccc3c83229ea9223a31192073