### PR TITLE
refactor: use cn utility for class merging

### DIFF
--- a/frontend/src/components/ui/Form/FormError.tsx
+++ b/frontend/src/components/ui/Form/FormError.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@/lib/utils';
 import React from 'react';
 
 export interface FormErrorProps {
@@ -10,7 +10,7 @@ export const FormError: React.FC<FormErrorProps> = ({ message, className }) => {
   if (!message) return null;
   return (
     <div
-      className={clsx(
+      className={cn(
         'rounded-md bg-error-50 dark:bg-error-900/50 p-4 border border-error-200 dark:border-error-800',
         className
       )}

--- a/frontend/src/components/ui/Input/Input.tsx
+++ b/frontend/src/components/ui/Input/Input.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { cn } from '@/lib/utils';
 import React, { forwardRef, useCallback, useId, useState } from 'react';
 
 import type { InputProps, InputVariant, InputSize, InputColor } from './Input.types';
@@ -71,16 +71,16 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const activeColor: InputColor = hasError ? 'error' : color;
 
     const variantClasses: Record<InputVariant, string> = {
-      outlined: clsx(
+      outlined: cn(
         'bg-transparent border rounded-md',
         hasError ? 'border-error-300 dark:border-error-600' : 'border-secondary-300 dark:border-secondary-600'
       ),
       filled: 'border-0 bg-secondary-100 dark:bg-secondary-800 rounded-md',
-      underlined: clsx(
+      underlined: cn(
         'border-0 border-b bg-transparent rounded-none px-0',
         hasError ? 'border-error-300 dark:border-error-600' : 'border-secondary-300 dark:border-secondary-600'
       ),
-      floating: clsx(
+      floating: cn(
         'bg-transparent border rounded-md pt-5',
         hasError ? 'border-error-300 dark:border-error-600' : 'border-secondary-300 dark:border-secondary-600'
       ),
@@ -101,7 +101,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 
     const showClearButton = clearable && value && !disabled;
 
-    const inputClasses = clsx(
+    const inputClasses = cn(
       'w-full transition-colors duration-200 outline-none focus:ring-2 focus:ring-offset-0',
       'placeholder-secondary-400 dark:placeholder-secondary-500 text-secondary-950 dark:text-secondary-50',
       'disabled:opacity-50 disabled:cursor-not-allowed',
@@ -114,24 +114,24 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       inputClassName
     );
 
-    const containerClasses = clsx(
+    const containerClasses = cn(
       'flex flex-col',
       fullWidth ? 'w-full' : 'inline-block',
       appearEffectClasses[appearEffect],
       wrapperClassName
     );
 
-    const labelClasses = clsx(
+    const labelClasses = cn(
       'block text-sm font-medium mb-1',
       isFocused ? inputColorStyles[activeColor].text : 'text-secondary-800 dark:text-secondary-300',
       disabled && 'opacity-50'
     );
 
-    const floatingLabelClasses = clsx(
+    const floatingLabelClasses = cn(
       'absolute text-sm transition-all duration-200',
       'left-2.5 bg-secondary-50 dark:bg-secondary-900 px-1 pointer-events-none',
       isFocused || hasValue
-        ? clsx('-translate-y-3 scale-75 origin-left', inputColorStyles[activeColor].text)
+        ? cn('-translate-y-3 scale-75 origin-left', inputColorStyles[activeColor].text)
         : 'text-secondary-500 dark:text-secondary-400 translate-y-2.5'
     );
 
@@ -203,7 +203,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 
         {displayHelperText && (
           <p
-            className={clsx(
+            className={cn(
               'text-xs mt-1',
               error ? 'text-error-600 dark:text-error-500' : 'text-secondary-600 dark:text-secondary-400'
             )}


### PR DESCRIPTION
## Summary
- refactor FormError and Input components to use `cn` utility instead of direct `clsx`
- simplify class name merging

## Testing
- `npm test` *(fails: expected spy to be called with different args)*
- `npm run lint` *(fails: 4 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689501b58d2883228f8cdcd6afc007a9