### PR TITLE
refactor: use shadcn button

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@hookform/resolvers": "^5.2.1",
         "@reduxjs/toolkit": "^2.2.1",
         "axios": "^1.6.7",
+        "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "framer-motion": "^12.5.0",
         "lucide-react": "^0.483.0",
@@ -6717,6 +6718,18 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
     },
     "node_modules/clean-css": {
       "version": "5.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,8 @@
     "react-redux": "^9.1.0",
     "react-router-dom": "^7.4.0",
     "tailwind-merge": "^3.0.2",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "class-variance-authority": "^0.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",

--- a/frontend/src/components/EventCard/EventCard.tsx
+++ b/frontend/src/components/EventCard/EventCard.tsx
@@ -86,7 +86,7 @@ const EventCard: React.FC<EventCardProps> = React.memo(({
           {path ? (
             <Link to={path} onClick={handleClick} className="w-full" data-testid="event-link-button">
               <Button
-                variant="primary"
+                variant="default"
                 size="md"
                 className="w-full rounded-md"
                 data-testid="event-button"
@@ -96,7 +96,7 @@ const EventCard: React.FC<EventCardProps> = React.memo(({
             </Link>
           ) : (
             <Button
-              variant="primary"
+              variant="default"
               size="md"
               className="w-full rounded-md"
               onClick={handleClick}

--- a/frontend/src/components/ui/Button/Button.stories.tsx
+++ b/frontend/src/components/ui/Button/Button.stories.tsx
@@ -12,12 +12,12 @@ const meta = {
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: ['primary', 'secondary', 'outline', 'danger', 'accent', 'ghost'],
+      options: ['default', 'secondary', 'destructive', 'outline', 'ghost', 'link'],
       description: 'Вариант стиля кнопки',
     },
     size: {
       control: { type: 'select' },
-      options: ['sm', 'md', 'lg'],
+      options: ['sm', 'md', 'lg', 'icon'],
       description: 'Размер кнопки',
     },
     fullWidth: {
@@ -47,9 +47,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Основные варианты кнопок
-export const Primary: Story = {
+export const Default: Story = {
   args: {
-    variant: 'primary',
+    variant: 'default',
     children: 'Кнопка',
   },
 };
@@ -61,7 +61,7 @@ export const Secondary: Story = {
   },
 };
 
-export const Outlined: Story = {
+export const Outline: Story = {
   args: {
     variant: 'outline',
     children: 'Кнопка',
@@ -69,17 +69,17 @@ export const Outlined: Story = {
 };
 
 // Добавляем истории для новых вариантов
-export const Danger: Story = {
+export const Destructive: Story = {
   args: {
-    variant: 'danger',
+    variant: 'destructive',
     children: 'Опасная кнопка',
   },
 };
 
-export const Accent: Story = {
+export const Link: Story = {
   args: {
-    variant: 'accent',
-    children: 'Акцентная кнопка',
+    variant: 'link',
+    children: 'Ссылка',
   },
 };
 
@@ -138,7 +138,7 @@ export const Loading: Story = {
 // Пример с иконками (в Storybook будут отображены строки вместо иконок)
 export const WithIcons: Story = {
   args: {
-    variant: 'primary',
+    variant: 'default',
     children: (
       <>
         <span role="img" aria-label="rocket" className="mr-2">

--- a/frontend/src/components/ui/Button/Button.tsx
+++ b/frontend/src/components/ui/Button/Button.tsx
@@ -1,9 +1,40 @@
-import { cn } from '@/lib/utils';
 import React from 'react';
+import { cva } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
 
 import { ButtonProps, ButtonSize } from './Button.types';
 
-// Добавляем компонент спиннера для состояния loading
+/**
+ * Variants for the button component following shadcn conventions.
+ */
+export const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'underline-offset-4 hover:underline text-primary',
+      },
+      size: {
+        sm: 'h-9 rounded-md px-3',
+        md: 'h-10 px-4 py-2',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'md',
+    },
+  }
+);
+
+// Spinner for loading state
 const Spinner: React.FC<{ sizeClass: string }> = ({ sizeClass }) => (
   <svg
     className={`animate-spin -ml-1 mr-3 ${sizeClass} text-current`}
@@ -28,76 +59,53 @@ const Spinner: React.FC<{ sizeClass: string }> = ({ sizeClass }) => (
 );
 
 /**
- * Кнопка - базовый UI компонент для взаимодействия пользователя
+ * Основной компонент кнопки.
  */
-export const Button: React.FC<ButtonProps> = ({
-  children,
-  className,
-  variant = 'primary',
-  size = 'md',
-  fullWidth = false,
-  disabled = false,
-  loading = false,
-  type = 'button',
-  onClick,
-  ...props
-}) => {
-  const baseClasses =
-    'inline-flex items-center justify-center rounded-md font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-secondary-900';
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant = 'default',
+      size = 'md',
+      fullWidth = false,
+      loading = false,
+      disabled = false,
+      type = 'button',
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const isDisabled = disabled || loading;
 
-  const variantClasses: Record<string, string> = {
-    primary:
-      'bg-primary-600 text-secondary-50 hover:bg-primary-700 focus:ring-primary-500 active:bg-primary-800 dark:bg-primary-500 dark:hover:bg-primary-600 dark:focus:ring-primary-400 dark:active:bg-primary-700',
-    secondary:
-      'bg-secondary-700 text-secondary-50 hover:bg-secondary-800 focus:ring-secondary-600 active:bg-secondary-900 dark:bg-secondary-600 dark:hover:bg-secondary-700 dark:focus:ring-secondary-500 dark:active:bg-secondary-800',
-    outline:
-      'bg-transparent border border-primary-600 text-primary-600 hover:bg-primary-50 dark:text-primary-400 dark:border-primary-400 dark:hover:bg-primary-900/20 focus:ring-primary-500 active:bg-primary-100 dark:active:bg-primary-900/30',
-    danger:
-      'bg-error-600 text-secondary-50 hover:bg-error-700 focus:ring-error-500 active:bg-error-800 dark:focus:ring-error-400',
-    accent:
-      'bg-accent-400 text-secondary-950 hover:bg-accent-500 focus:ring-accent-300 active:bg-accent-600 dark:focus:ring-accent-200',
-    ghost:
-      'bg-transparent text-secondary-700 hover:bg-secondary-100 focus:ring-secondary-500 active:bg-secondary-200 dark:text-secondary-300 dark:hover:bg-secondary-700 dark:focus:ring-secondary-400 dark:active:bg-secondary-600',
-  };
+    const spinnerSizeClasses: Record<ButtonSize, string> = {
+      sm: 'h-4 w-4',
+      md: 'h-5 w-5',
+      lg: 'h-6 w-6',
+      icon: 'h-5 w-5',
+    };
 
-  const sizeClasses: Record<ButtonSize, string> = {
-    sm: 'text-sm px-3 py-1.5',
-    md: 'text-base px-4 py-2',
-    lg: 'text-lg px-6 py-3',
-  };
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(
+          buttonVariants({ variant, size }),
+          fullWidth && 'w-full',
+          className
+        )}
+        disabled={isDisabled}
+        data-testid={`button-${variant}`}
+        {...props}
+      >
+        {loading && <Spinner sizeClass={spinnerSizeClasses[size]} />}
+        {children}
+      </button>
+    );
+  }
+);
 
-  const spinnerSizeClasses: Record<ButtonSize, string> = {
-    sm: 'h-4 w-4',
-    md: 'h-5 w-5',
-    lg: 'h-6 w-6',
-  };
+Button.displayName = 'Button';
 
-  const widthClass = fullWidth ? 'w-full' : '';
-  const isDisabled = disabled || loading;
-  const disabledClass = isDisabled ? 'opacity-50 cursor-not-allowed' : '';
+export default Button;
 
-  const normalizedSize = size;
-
-  const buttonClasses = cn(
-    baseClasses,
-    variantClasses[variant === 'outlined' ? 'outline' : variant],
-    sizeClasses[size],
-    widthClass,
-    disabledClass,
-    className
-  );
-
-  return (
-    <button
-      type={type}
-      className={buttonClasses}
-      disabled={isDisabled}
-      onClick={onClick}
-      data-testid={`button-${variant}`}
-      {...props}
-    >
-      {loading && <Spinner sizeClass={spinnerSizeClasses[normalizedSize]} />}
-      {children}
-    </button>
-  );
-};

--- a/frontend/src/components/ui/Button/Button.types.ts
+++ b/frontend/src/components/ui/Button/Button.types.ts
@@ -1,15 +1,14 @@
 import { ButtonHTMLAttributes } from 'react';
 
 export type ButtonVariant =
-  | 'primary'
+  | 'default'
   | 'secondary'
+  | 'destructive'
   | 'outline'
-  | 'outlined' // alias для совместимости со старыми примерами
-  | 'danger'
-  | 'accent'
-  | 'ghost';
+  | 'ghost'
+  | 'link';
 
-export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonSize = 'sm' | 'md' | 'lg' | 'icon';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**

--- a/frontend/src/components/ui/Card/Card.stories.tsx
+++ b/frontend/src/components/ui/Card/Card.stories.tsx
@@ -64,11 +64,11 @@ const renderCardContent = (title: string, content: React.ReactNode, actions?: Re
 
 export const Default: Story = {
   args: {
-    children: renderCardContent(
-      'Стандартная карточка',
-      <Typography>Это содержимое стандартной карточки.</Typography>,
-      <Button variant="primary" size="sm">Действие</Button>
-    ),
+      children: renderCardContent(
+        'Стандартная карточка',
+        <Typography>Это содержимое стандартной карточки.</Typography>,
+        <Button variant="default" size="sm">Действие</Button>
+      ),
   },
 };
 

--- a/frontend/src/components/ui/Modal/Modal.stories.tsx
+++ b/frontend/src/components/ui/Modal/Modal.stories.tsx
@@ -69,7 +69,7 @@ export const Basic: Story = {
         <Button variant="outline" onClick={noop}>
           Отмена
         </Button>
-        <Button variant="primary" onClick={noop}>
+        <Button variant="default" onClick={noop}>
           ОК
         </Button>
       </>
@@ -101,7 +101,7 @@ export const WithDetailedContent: Story = {
       </div>
     ),
     actions: (
-      <Button variant="primary" onClick={noop}>
+      <Button variant="default" onClick={noop}>
         Понятно
       </Button>
     ),
@@ -117,7 +117,7 @@ export const SmallSize: Story = {
     maxWidth: 'sm',
     children: 'Это маленькое модальное окно.',
     actions: (
-      <Button variant="primary" onClick={noop}>
+      <Button variant="default" onClick={noop}>
         ОК
       </Button>
     ),
@@ -136,7 +136,7 @@ export const MediumSize: Story = {
     maxWidth: 'md',
     children: 'Это модальное окно среднего размера.',
     actions: (
-      <Button variant="primary" onClick={noop}>
+      <Button variant="default" onClick={noop}>
         ОК
       </Button>
     ),
@@ -155,7 +155,7 @@ export const LargeSize: Story = {
     maxWidth: 'lg',
     children: 'Это большое модальное окно.',
     actions: (
-      <Button variant="primary" onClick={noop}>
+      <Button variant="default" onClick={noop}>
         ОК
       </Button>
     ),
@@ -174,7 +174,7 @@ export const ExtraLargeSize: Story = {
     maxWidth: 'xl',
     children: 'Это очень большое модальное окно.',
     actions: (
-      <Button variant="primary" onClick={noop}>
+      <Button variant="default" onClick={noop}>
         ОК
       </Button>
     ),
@@ -193,7 +193,7 @@ export const FullWidth: Story = {
     maxWidth: 'full',
     children: 'Это модальное окно на всю ширину экрана.',
     actions: (
-      <Button variant="primary" onClick={noop}>
+      <Button variant="default" onClick={noop}>
         ОК
       </Button>
     ),
@@ -210,7 +210,7 @@ const ModalDemo = () => {
 
   return (
     <div>
-      <Button variant="primary" onClick={() => setOpen(true)}>
+      <Button variant="default" onClick={() => setOpen(true)}>
         Открыть модальное окно
       </Button>
       <Modal
@@ -222,7 +222,7 @@ const ModalDemo = () => {
             <Button variant="outline" onClick={() => setOpen(false)}>
               Отмена
             </Button>
-            <Button variant="primary" onClick={() => setOpen(false)}>
+            <Button variant="default" onClick={() => setOpen(false)}>
               ОК
             </Button>
           </>

--- a/frontend/src/docs/examples/CustomThemingExample.tsx
+++ b/frontend/src/docs/examples/CustomThemingExample.tsx
@@ -39,14 +39,14 @@ const CustomThemingExample = () => {
 
           <div className="flex items-center space-x-2">
             <Button
-              variant={darkMode ? 'primary' : 'outlined'}
+              variant={darkMode ? 'default' : 'outline'}
               onClick={() => setDarkMode(true)}
               className="flex-1"
             >
               Темная тема
             </Button>
             <Button
-              variant={!darkMode ? 'primary' : 'outlined'}
+              variant={!darkMode ? 'default' : 'outline'}
               onClick={() => setDarkMode(false)}
               className="flex-1"
             >
@@ -80,7 +80,7 @@ const CustomThemingExample = () => {
           />
 
           <Button
-            variant="primary"
+            variant="default"
             className={customButtonClass}
             onClick={() => setModalOpen(true)}
           >
@@ -88,13 +88,13 @@ const CustomThemingExample = () => {
           </Button>
 
           <div className="flex space-x-2 mt-4">
-            <Button variant="primary" size="sm" className={customButtonClass}>
+            <Button variant="default" size="sm" className={customButtonClass}>
               Маленькая кнопка
             </Button>
-            <Button variant="primary" className={customButtonClass}>
+            <Button variant="default" className={customButtonClass}>
               Средняя
             </Button>
-            <Button variant="primary" size="lg" className={customButtonClass}>
+            <Button variant="default" size="lg" className={customButtonClass}>
               Большая кнопка
             </Button>
           </div>
@@ -119,7 +119,7 @@ const customButtonClass = 'custom-button-color hover:bg-opacity-90 text-white';
 
 // Использование в компонентах
 <div className={\`p-8 \${darkModeClass}\`}>
-  <Button variant="primary" className={customButtonClass}>
+  <Button variant="default" className={customButtonClass}>
     Кастомная кнопка
   </Button>
 </div>`}
@@ -135,14 +135,14 @@ const customButtonClass = 'custom-button-color hover:bg-opacity-90 text-white';
         actions={
           <>
             <Button
-              variant="outlined"
+              variant="outline"
               onClick={() => setModalOpen(false)}
               className={darkMode ? 'text-white border-white' : ''}
             >
               Отмена
             </Button>
             <Button
-              variant="primary"
+              variant="default"
               onClick={() => setModalOpen(false)}
               className={customButtonClass}
             >

--- a/frontend/src/docs/examples/LoginFormExample.tsx
+++ b/frontend/src/docs/examples/LoginFormExample.tsx
@@ -98,7 +98,7 @@ const LoginFormExample = () => {
           </Typography>
         </div>
 
-        <Button variant="primary" type="submit" fullWidth>
+        <Button variant="default" type="submit" fullWidth>
           Войти
         </Button>
 

--- a/frontend/src/docs/examples/RegisterFormExample.tsx
+++ b/frontend/src/docs/examples/RegisterFormExample.tsx
@@ -226,7 +226,7 @@ const RegisterFormExample = () => {
           )}
         </div>
 
-        <Button variant="primary" type="submit" fullWidth className="mt-6">
+        <Button variant="default" type="submit" fullWidth className="mt-6">
           Зарегистрироваться
         </Button>
 

--- a/frontend/src/pages/UIKitPage/UIKitPage.tsx
+++ b/frontend/src/pages/UIKitPage/UIKitPage.tsx
@@ -40,9 +40,9 @@ const ButtonSection = () => {
         <div className="space-y-2">
           <Typography variant="subtitle-1">Primary</Typography>
           <div className="flex flex-wrap gap-2">
-            <Button variant="primary" size="sm">Маленькая</Button>
-            <Button variant="primary">Средняя</Button>
-            <Button variant="primary" size="lg">Большая</Button>
+            <Button variant="default" size="sm">Маленькая</Button>
+            <Button variant="default">Средняя</Button>
+            <Button variant="default" size="lg">Большая</Button>
           </div>
         </div>
         
@@ -69,22 +69,22 @@ const ButtonSection = () => {
         <div className="space-y-2">
           <Typography variant="subtitle-1">Danger</Typography>
           <div className="flex flex-wrap gap-2">
-            <Button variant="danger">Опасное действие</Button>
-            <Button variant="danger" disabled>Недоступно</Button>
+            <Button variant="destructive">Опасное действие</Button>
+            <Button variant="destructive" disabled>Недоступно</Button>
           </div>
         </div>
         
         <div className="space-y-2">
           <Typography variant="subtitle-1">Loading</Typography>
           <div className="flex flex-wrap gap-2">
-            <Button variant="primary" loading>Загрузка...</Button>
+            <Button variant="default" loading>Загрузка...</Button>
             <Button variant="secondary" loading>Загрузка...</Button>
           </div>
         </div>
         
         <div className="space-y-2">
           <Typography variant="subtitle-1">Full Width</Typography>
-          <Button variant="primary" fullWidth>Во всю ширину</Button>
+          <Button variant="default" fullWidth>Во всю ширину</Button>
         </div>
       </div>
     </Section>
@@ -157,7 +157,7 @@ const CardSection = () => {
             </Typography>
           </CardContent>
           <CardFooter>
-            <Button variant="primary" size="sm">Действие</Button>
+            <Button variant="default" size="sm">Действие</Button>
           </CardFooter>
         </Card>
         
@@ -229,7 +229,7 @@ const CardSection = () => {
             </Typography>
           </CardContent>
           <CardFooter>
-            <Button variant="primary" size="sm">Действие</Button>
+            <Button variant="default" size="sm">Действие</Button>
           </CardFooter>
         </Card>
         
@@ -370,7 +370,7 @@ const ModalSection = () => {
     <Section title="Модальные окна">
       <div className="space-y-4">
         <Button 
-          variant="primary" 
+          variant="default" 
           onClick={() => setIsOpen(true)}
         >
           Открыть модальное окно
@@ -395,7 +395,7 @@ const ModalSection = () => {
             <Button variant="outline" onClick={() => setIsOpen(false)}>
               Отмена
             </Button>
-            <Button variant="primary" onClick={() => setIsOpen(false)}>
+            <Button variant="default" onClick={() => setIsOpen(false)}>
               Подтвердить
             </Button>
           </div>

--- a/frontend/src/types/ui.ts
+++ b/frontend/src/types/ui.ts
@@ -10,7 +10,7 @@ import { TypographyAlign, TypographyColor, TypographyVariant } from '@/component
 export type Size = 'sm' | 'md' | 'lg';
 
 // Основные типы вариантов
-export type Variant = 'primary' | 'secondary' | 'outlined' | 'outline' | 'text' | 'filled' | 'gradient';
+export type Variant = 'default' | 'secondary' | 'destructive' | 'outline' | 'text' | 'filled' | 'gradient';
 
 // Основные типы цветов
 export type Color =


### PR DESCRIPTION
## Summary
- replace custom button with shadcn variant and add class-variance-authority
- drop outlined alias and update all consumers to default, secondary, destructive, etc.
- cleanup variant color mappings to rely on theme values

## Testing
- `npm test` *(fails: expected spy to be called with username 'test@example.com')*
- `npm run lint` *(fails: Parsing error in Header/types.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68950534f89c83228a8723604b847508